### PR TITLE
Allow calling a method with no parameters to output a new line

### DIFF
--- a/src/TerminalObject/Out.php
+++ b/src/TerminalObject/Out.php
@@ -12,7 +12,7 @@ class Out extends BaseTerminalObject
 
     protected $content;
 
-    public function __construct($content)
+    public function __construct($content = "")
     {
         $this->content = $content;
     }


### PR DESCRIPTION
Previously calling the out() method with no parameters would cause an undefined variable notice
