### PR TITLE
Added support for labels on the advance() method

### DIFF
--- a/src/TerminalObject/Dynamic/Progress.php
+++ b/src/TerminalObject/Dynamic/Progress.php
@@ -92,11 +92,12 @@ class Progress extends BaseDynamicTerminalObject
      * Increments the current position we are at and re-writes the progress bar
      *
      * @param integer $increment The number of items to increment by
+     * @param string $label
      */
 
-    public function advance($increment = 1)
+    public function advance($increment = 1, $label = null)
     {
-        $this->current($this->current + $increment);
+        $this->current($this->current + $increment, $label);
     }
 
     /**
@@ -207,5 +208,4 @@ class Progress extends BaseDynamicTerminalObject
     {
         return "\n" . $this->util->cursor->startOfCurrentLine() . $this->util->cursor->deleteCurrentLine() . $label;
     }
-
 }

--- a/tests/ProgressTest.php
+++ b/tests/ProgressTest.php
@@ -219,4 +219,20 @@ class ProgressTest extends TestBase
     }
 
 
+    /** @test */
+
+    public function it_can_output_a_progress_bar_using_increments_with_label()
+    {
+        $this->shouldWrite('');
+        $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(10)} 10%\n\r\e[Kstart\e[0m");
+        $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(20)} 20%\n\r\e[Knext\e[0m");
+        $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(100)} 100%\e[0m");
+
+        $progress = $this->cli->progress()->total(10);
+        $progress->advance(1, "start");
+        $progress->advance(1, "next");
+        $progress->advance(8, "final");
+    }
+
+
 }


### PR DESCRIPTION
Requested in #32 

I've added some tests, and mirrored the existing tests for labels (including not displaying a label at 100%)
