### PR TITLE
Support non ansi terminals

### DIFF
--- a/src/Decorator/Parser.php
+++ b/src/Decorator/Parser.php
@@ -97,6 +97,17 @@ class Parser
     }
 
     /**
+     * Get the regular expression that can be used to parse the string for tags
+     *
+     * @return string
+     */
+
+    protected function getRegexForTags()
+    {
+        return '(<(?:(?:(?:\\\)*\/)*(?:' . implode('|', array_keys($this->all)) . '))>)';
+    }
+
+    /**
      * Parse the string for tags and replace them with their codes
      *
      * @param  string $str
@@ -105,8 +116,7 @@ class Parser
 
     protected function parse($str)
     {
-        $regex = '(<(?:(?:(?:\\\)*\/)*(?:' . implode('|', array_keys($this->all)) . '))>)';
-        $count = preg_match_all($regex, $str, $matches);
+        $count = preg_match_all($this->getRegexForTags(), $str, $matches);
 
         // If we didn't find anything, return the string right back
         if (!$count || !is_array($matches)) {
@@ -117,6 +127,18 @@ class Parser
         $matches = reset($matches);
 
         return $this->parseTags($str, $matches);
+    }
+
+    /**
+     * Parse the string for tags and remove them
+     *
+     * @param  string $str
+     * @return string
+     */
+
+    public function ignore($str)
+    {
+        return preg_replace($this->getRegexForTags(), "", $str);
     }
 
     /**
@@ -215,5 +237,4 @@ class Parser
     {
         return $this->codeStr($this->current);
     }
-
 }

--- a/src/TerminalObject/BaseTerminalObject.php
+++ b/src/TerminalObject/BaseTerminalObject.php
@@ -45,4 +45,15 @@ abstract class BaseTerminalObject implements TerminalObjectInterface
     {
         return false;
     }
+
+    /**
+     * Check if the stream supports colors.
+     *
+     * @return bool
+     */
+
+    public function hasColorSupport()
+    {
+        return $this->util->system->hasColorSupport();
+    }
 }

--- a/src/TerminalObject/BaseTerminalObject.php
+++ b/src/TerminalObject/BaseTerminalObject.php
@@ -52,8 +52,8 @@ abstract class BaseTerminalObject implements TerminalObjectInterface
      * @return bool
      */
 
-    public function hasColorSupport()
+    public function hasAnsiSupport()
     {
-        return $this->util->system->hasColorSupport();
+        return $this->util->system->hasAnsiSupport();
     }
 }

--- a/src/TerminalObject/Router/BasicRouter.php
+++ b/src/TerminalObject/Router/BasicRouter.php
@@ -39,8 +39,13 @@ class BasicRouter extends BaseRouter implements RouterInterface
                 $this->output->sameLine();
             }
 
-            $this->output->write($obj->getParser()->apply($result));
+            if ($obj->hasAnsiSupport()) {
+                $result = $obj->getParser()->apply($result);
+            } else {
+                $result = $obj->getParser()->ignore($result);
+            }
+
+            $this->output->write($result);
         }
     }
-
 }

--- a/src/TerminalObject/TerminalObjectInterface.php
+++ b/src/TerminalObject/TerminalObjectInterface.php
@@ -21,5 +21,5 @@ interface TerminalObjectInterface
     /**
      * @return boolean
      */
-    public function hasColorSupport();
+    public function hasAnsiSupport();
 }

--- a/src/TerminalObject/TerminalObjectInterface.php
+++ b/src/TerminalObject/TerminalObjectInterface.php
@@ -17,4 +17,9 @@ interface TerminalObjectInterface
      * @return boolean
      */
     public function sameLine();
+
+    /**
+     * @return boolean
+     */
+    public function hasColorSupport();
 }

--- a/src/Util/Dimensions.php
+++ b/src/Util/Dimensions.php
@@ -2,8 +2,8 @@
 
 namespace League\CLImate\Util;
 
-use League\CLImate\Util\System\Linux;
-use League\CLImate\Util\System\Windows;
+use League\CLImate\Util\System\SystemFactory;
+use League\CLImate\Util\System\SystemInterface;
 
 class Dimensions {
 
@@ -15,14 +15,12 @@ class Dimensions {
 
     protected $system;
 
-    public function __construct($system = null)
+    public function __construct(SystemInterface $system = null)
     {
         if ($system) {
             $this->system = $system;
-        } elseif (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-            $this->system = new Windows();
         } else {
-            $this->system = new Linux();
+            $this->system = SystemFactory::getInstance();
         }
     }
 
@@ -61,5 +59,4 @@ class Dimensions {
     {
         return (is_numeric($num)) ? $num : $default;
     }
-
 }

--- a/src/Util/System/Linux.php
+++ b/src/Util/System/Linux.php
@@ -30,4 +30,16 @@ class Linux implements SystemInterface
         return (is_numeric($height)) ? $height : null;
     }
 
+    /**
+     * Check if the stream supports ansi escape characters.
+     *
+     * Based on https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Output/StreamOutput.php
+     *
+     * @return bool
+     */
+
+    public function hasAnsiSupport()
+    {
+        return function_exists('posix_isatty') && @posix_isatty(STDOUT);
+    }
 }

--- a/src/Util/System/SystemFactory.php
+++ b/src/Util/System/SystemFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace League\CLImate\Util\System;
+
+class SystemFactory
+{
+    /**
+     * @var SystemInterface $instance An instance of the system class for the operating system we are running on
+     */
+    protected static $instance;
+
+    /**
+     * Get an instance of the appropriate System class
+     *
+     * @return SystemInterface
+     */
+    public static function getInstance()
+    {
+        if (static::$instance) {
+            return static::$instance;
+        }
+
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            static::$instance = new Windows();
+        } else {
+            static::$instance = new Linux();
+        }
+
+        return static::$instance;
+    }
+}

--- a/src/Util/System/SystemInterface.php
+++ b/src/Util/System/SystemInterface.php
@@ -16,4 +16,11 @@ interface SystemInterface
 
     public function height();
 
+    /**
+     * Check if the stream supports ansi escape characters.
+     *
+     * @return bool
+     */
+
+    public function hasAnsiSupport();
 }

--- a/src/Util/System/Windows.php
+++ b/src/Util/System/Windows.php
@@ -51,4 +51,23 @@ class Windows implements SystemInterface
         return (!empty($matches[1])) ? $matches[1] : [];
     }
 
+    /**
+     * Check if the stream supports ansi escape characters.
+     *
+     * Based on https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Output/StreamOutput.php
+     *
+     * @return bool
+     */
+
+    public function hasAnsiSupport()
+    {
+        if (getenv('ANSICON') === true) {
+            return true;
+        }
+        if (getenv('ConEmuANSI') === 'ON') {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/src/Util/UtilFactory.php
+++ b/src/Util/UtilFactory.php
@@ -2,8 +2,18 @@
 
 namespace League\CLImate\Util;
 
+use League\CLImate\Util\System\SystemFactory;
+
 class UtilFactory
 {
+    /**
+     * A instance of the appropriate System class
+     *
+     * @var \League\CLImate\Util\System\SystemInterface
+     */
+
+    public $system;
+
     /**
      * A instance of the Dimension class
      *
@@ -22,8 +32,8 @@ class UtilFactory
 
     public function __construct()
     {
-        $this->dimensions = new Dimensions();
+        $this->system     = SystemFactory::getInstance();
+        $this->dimensions = new Dimensions($this->system);
         $this->cursor     = new Cursor();
     }
-
 }

--- a/tests/AnsiTest.php
+++ b/tests/AnsiTest.php
@@ -1,0 +1,48 @@
+<?php
+
+require_once 'TestBase.php';
+
+use League\CLImate\TerminalObject\Router\BasicRouter;
+use League\CLImate\Decorator\Style;
+
+class AnsiTest extends TestBase
+{
+
+    /** @test */
+
+    public function it_can_output_with_ansi()
+    {
+        $router = new BasicRouter();
+        $router->output($this->output);
+
+        $obj = Mockery::mock('League\CLImate\TerminalObject');
+        $obj->shouldReceive('result')->once()->andReturn("<green>I am green</green>");
+        $obj->shouldReceive('sameLine')->once()->andReturn(false);
+        $obj->shouldReceive('hasAnsiSupport')->once()->andReturn(true);
+        $obj->shouldReceive('getParser')->once()->andReturn((new Style)->parser());
+
+        $this->shouldWrite("\e[m\e[32mI am green\e[0m\e[0m");
+
+        $router->execute($obj);
+    }
+
+
+    /** @test */
+
+    public function it_can_output_without_ansi()
+    {
+        $router = new BasicRouter();
+        $router->output($this->output);
+
+        $obj = Mockery::mock('League\CLImate\TerminalObject');
+        $obj->shouldReceive('result')->once()->andReturn("<green>I am not green</green>");
+        $obj->shouldReceive('sameLine')->once()->andReturn(false);
+        $obj->shouldReceive('hasAnsiSupport')->once()->andReturn(false);
+        $obj->shouldReceive('getParser')->once()->andReturn((new Style)->parser());
+
+        $this->shouldWrite("I am not green");
+
+        $router->execute($obj);
+    }
+
+}


### PR DESCRIPTION
When using climate on a terminal that doesn't support ansi escape sequences they are just dumped out with the content.

Taking a lead from symfony/console (https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Output/StreamOutput.php#L95) I've added support for "undecorated" output.

This is only for basic output, it doesn't handle dynamic output (I didn't want the pr to grow too large).
What are your thoughts on this? Useful? Misuse of CLImate?