### PR TITLE
Create some more standard Writer classes

### DIFF
--- a/src/Util/Writer/Buffer.php
+++ b/src/Util/Writer/Buffer.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace League\CLImate\Util\Writer;
+
+class Buffer implements WriterInterface
+{
+    /**
+     * @var string $contents The buffered data.
+     */
+    protected $contents = "";
+
+    /**
+     * Write the content to the buffer.
+     *
+     * @param string $content
+     *
+     * @return void
+     */
+    public function write($content)
+    {
+        $this->contents .= $content;
+    }
+
+
+    /**
+     * Get the buffered data.
+     *
+     * @return string
+     */
+    public function get()
+    {
+        return $this->contents;
+    }
+
+    /**
+     * Clean the buffer and throw away any data.
+     *
+     * @return void
+     */
+    public function clean()
+    {
+        $this->contents = "";
+    }
+}

--- a/src/Util/Writer/StdErr.php
+++ b/src/Util/Writer/StdErr.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace League\CLImate\Util\Writer;
+
+class StdErr implements WriterInterface
+{
+    /**
+     * Write the content to the stream
+     *
+     * @param string $content
+     *
+     * @return void
+     */
+    public function write($content)
+    {
+        fwrite(\STDERR, $content);
+    }
+}

--- a/src/Util/Writer/StdOut.php
+++ b/src/Util/Writer/StdOut.php
@@ -8,10 +8,11 @@ class StdOut implements WriterInterface
      * Write the content to the stream
      *
      * @param  string $content
+     *
+     * @return void
      */
     public function write($content)
     {
-        fwrite(STDOUT, $content);
+        fwrite(\STDOUT, $content);
     }
-
 }

--- a/src/Util/Writer/WriterInterface.php
+++ b/src/Util/Writer/WriterInterface.php
@@ -6,6 +6,8 @@ interface WriterInterface
 {
     /**
      * @param  string $content
+     *
+     * @return void
      */
     public function write($content);
 }

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -1,0 +1,54 @@
+<?php
+
+require_once 'TestBase.php';
+
+class BufferTest extends TestBase
+{
+
+    /** @test */
+    public function it_can_buffer_content()
+    {
+        $buffer = new League\CLImate\Util\Writer\Buffer;
+        $output = new League\CLImate\Util\Output($buffer);
+
+        $output->write("Oh, you're still here.");
+
+        $this->assertSame("Oh, you're still here.\n", $buffer->get());
+    }
+
+    /** @test */
+    public function it_can_buffer_content_without_a_new_line()
+    {
+        $buffer = new League\CLImate\Util\Writer\Buffer;
+        $output = new League\CLImate\Util\Output($buffer);
+
+        $output->sameLine()->write("Oh, you're still here.");
+
+        $this->assertSame("Oh, you're still here.", $buffer->get());
+    }
+
+    /** @test */
+    public function it_can_buffer_multiple_lines()
+    {
+        $buffer = new League\CLImate\Util\Writer\Buffer;
+        $output = new League\CLImate\Util\Output($buffer);
+
+        $output->write("Oh, you're still here.");
+        $output->write("Also am I.");
+
+        $this->assertSame("Oh, you're still here.\nAlso am I.\n", $buffer->get());
+    }
+
+    /** @test */
+    public function it_can_clean_buffered_content()
+    {
+        $buffer = new League\CLImate\Util\Writer\Buffer;
+        $output = new League\CLImate\Util\Output($buffer);
+
+        $output->write("Oh, you're still here.");
+        $buffer->clean();
+        $output->write("I am on my own.");
+
+        $this->assertSame("I am on my own.\n", $buffer->get());
+    }
+}


### PR DESCRIPTION
* StdErr (to go with StdOut, related to #37)
* Buffer (to stash content for using later, would help with #44 and #55)

Example usage:
```php
use League\CLImate\Util\Writer\Buffer;
use League\CLImate\Util\Output;

$buffer = new Buffer;
$climate->setOutput(new Output($buffer));

$climate->out("Don't output me");
$climate->out("Or me");

file_put_contents("/tmp/climate.log", $buffer->get());
```

Would result in `/tmp/climate.log` containing:
```
Don't output me
Or me
```