### PR TITLE
Prompts for inputs won't change case if first input is not accepted

### DIFF
--- a/src/TerminalObject/Dynamic/Input.php
+++ b/src/TerminalObject/Dynamic/Input.php
@@ -212,11 +212,13 @@ class Input extends DynamicTerminalObject
     protected function isAcceptableResponse($response)
     {
         if (!$this->strict) {
-            $this->acceptable = $this->levelPlayingField((array) $this->acceptable);
+            $acceptable = $this->levelPlayingField((array) $this->acceptable);
             $response         = $this->levelPlayingField($response);
+        } else {
+            $acceptable = $this->acceptable;
         }
 
-        return in_array($response, $this->acceptable);
+        return in_array($response, $acceptable);
     }
 
     /**

--- a/tests/InputTest.php
+++ b/tests/InputTest.php
@@ -85,6 +85,23 @@ class InputTest extends TestBase
     }
 
     /** @test */
+    public function it_will_display_acceptable_responses_with_same_format_if_input_fails()
+    {
+        $this->shouldReadAndReturn('Nothing.');
+        $this->shouldReadAndReturn('Stuff.');
+        $this->shouldReceiveSameLine();
+        $this->shouldWrite("\e[mSo what is up? [Everything./Stuff.] \e[0m", 2);
+
+        $input = $this->cli->input('So what is up?', $this->reader);
+
+        $input->accept(['Everything.', 'Stuff.'], true);
+
+        $response = $input->prompt();
+
+        $this->assertSame('Stuff.', $response);
+    }
+
+    /** @test */
     public function it_will_format_the_default_acceptable_response()
     {
         $this->shouldReadAndReturn('Stuff.');


### PR DESCRIPTION
Before this patch, if you didn't enter an acceptable response (in non-strict mode) you'd get:

How you doin? [Fine/OK] Great
How you doin? [fine/ok]

The second prompt shows the acceptable input lowercased instead of the original provided acceptable input casing.