### PR TITLE
Allow CLImate to be used as a PSR-3 logger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         }
     ],
     "require": {
+        "psr/log": "~1.0",
         "php": ">=5.4.0"
     },
     "require-dev": {

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace League\CLImate;
+
+use Psr\Log\AbstractLogger;
+
+/**
+ * A PSR-3 compatiable logger that uses CLImate for output.
+ */
+class Logger extends AbstractLogger
+{
+    /**
+     * @var CLImate $climate The underlying climate instance we are using for output.
+     */
+    protected $climate;
+
+    /**
+     * Create a new Logger instance.
+     *
+     * @param CLImate $climate An existing CLImate instance to use for output
+     */
+    public function __construct(CLImate $climate = null)
+    {
+        if ($climate === null) {
+            $climate = new CLImate;
+        }
+        $this->climate = $climate;
+
+        # Define some default styles to use for the
+        $commands = [
+            "emergency" =>  ["white", "bold", "background_red"],
+            "alert"     =>  ["white", "background_yellow"],
+            "critical"  =>  ["red", "bold"],
+            "error"     =>  ["red"],
+            "warning"   =>  "yellow",
+            "notice"    =>  "light_cyan",
+            "info"      =>  "green",
+            "debug"     =>  "dark_gray",
+        ];
+
+        # If any of the required styles are not defined then define them now
+        foreach ($commands as $command => $style) {
+            if (!$this->climate->style->get($command)) {
+                $this->climate->style->addCommand($command, $style);
+            }
+        }
+    }
+
+    /**
+     * Log messages to a CLImate instance.
+     *
+     * @param mixed          $level    The level of the log message
+     * @param string|object  $message  If an object is passed it must implement __toString()
+     * @param array          $context  Placeholders to be substituted in the message
+     *
+     * @return static
+     */
+    public function log($level, $message, array $context = [])
+    {
+        # Handle objects implementing __toString
+        $message = (string) $message;
+
+        # Handle any placeholders in the $context array
+        foreach ($context as $key => $val) {
+            $placeholder = "{" . $key . "}";
+
+            # If this context key is used as a placeholder, then replace it, and remove it from the $context array
+            if (strpos($message, $placeholder) !== false) {
+                $val = (string) $val;
+                $message = str_replace($placeholder, $val, $message);
+                unset($context[$key]);
+            }
+        }
+
+        # Send the message to the climate instance
+        $this->climate->{$level}($message);
+
+        # Append any context information not used as placeholders
+        foreach ($context as $key => $val) {
+            $val = (string) $val;
+            $this->climate->tab()->{$level}("{$key}: {$val}");
+        }
+
+        return $this;
+    }
+}

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -76,11 +76,34 @@ class Logger extends AbstractLogger
         $this->climate->{$level}($message);
 
         # Append any context information not used as placeholders
-        foreach ($context as $key => $val) {
-            $val = (string) $val;
-            $this->climate->tab()->{$level}("{$key}: {$val}");
-        }
+        $this->outputRecursiveContext($level, $context, 1);
 
         return $this;
+    }
+
+    /**
+     * Handle recursive arrays in the logging context.
+     *
+     * @param mixed  $level    The level of the log message
+     * @param array  $context  The array of context to output
+     * @param int    $indent   The current level of indentation to be used
+     *
+     * @return vvoid
+     */
+    protected function outputRecursiveContext($level, array $context, $indent)
+    {
+        foreach ($context as $key => $val) {
+            $this->climate->tab($indent);
+
+            $this->climate->{$level}()->inline("{$key}: ");
+
+            if (is_array($val)) {
+                $this->climate->{$level}("[");
+                $this->outputRecursiveContext($level, $val, $indent + 1);
+                $this->climate->tab($indent)->{$level}("]");
+            } else {
+                $this->climate->{$level}((string) $val);
+            }
+        }
     }
 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -95,8 +95,12 @@ class LoggerTest extends PHPUnit_Framework_TestCase
     public function it_can_log_with_context()
     {
         $this->cli->shouldReceive("info")->once()->with("With context");
-        $this->cli->shouldReceive("tab")->once()->andReturn($this->cli);
-        $this->cli->shouldReceive("info")->once()->with("context: CONTEXT");
+
+        $this->cli->shouldReceive("tab")->with(1)->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("info")->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("inline")->once()->with("context: ");
+        $this->cli->shouldReceive("info")->once()->with("CONTEXT");
+
         $this->logger->info("With context", [
             "context"   =>  "CONTEXT",
         ]);
@@ -122,11 +126,65 @@ class LoggerTest extends PHPUnit_Framework_TestCase
     public function it_can_log_with_placeholders_and_context()
     {
         $this->cli->shouldReceive("info")->once()->with("I am Spartacus!");
-        $this->cli->shouldReceive("tab")->once()->andReturn($this->cli);
-        $this->cli->shouldReceive("info")->once()->with("date: 2015-03-01");
+
+        $this->cli->shouldReceive("tab")->with(1)->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("info")->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("inline")->once()->with("date: ");
+        $this->cli->shouldReceive("info")->once()->with("2015-03-01");
+
         $this->logger->info("I am {username}!", [
             "username"  =>  "Spartacus",
             "date"      =>  "2015-03-01",
+        ]);
+    }
+
+    /** @test */
+    public function it_can_log_with_recursive_output()
+    {
+        $this->cli->shouldReceive("info")->once()->with("INFO");
+
+        $this->cli->shouldReceive("tab")->with(1)->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("info")->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("inline")->once()->with("data: ");
+        $this->cli->shouldReceive("info")->once()->with("[");
+
+        $this->cli->shouldReceive("tab")->with(2)->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("info")->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("inline")->once()->with("field1: ");
+        $this->cli->shouldReceive("info")->once()->with("One");
+
+        $this->cli->shouldReceive("tab")->with(2)->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("info")->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("inline")->once()->with("field2: ");
+        $this->cli->shouldReceive("info")->once()->with("Two");
+
+        $this->cli->shouldReceive("tab")->with(2)->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("info")->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("inline")->once()->with("extra: ");
+        $this->cli->shouldReceive("info")->once()->with("[");
+
+        $this->cli->shouldReceive("tab")->with(3)->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("info")->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("inline")->once()->with("0: ");
+        $this->cli->shouldReceive("info")->once()->with("Three");
+
+        $this->cli->shouldReceive("tab")->with(3)->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("info")->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("inline")->once()->with("1: ");
+        $this->cli->shouldReceive("info")->once()->with("Four");
+
+        $this->cli->shouldReceive("tab")->with(2)->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("info")->once()->with("]");
+
+        $this->cli->shouldReceive("tab")->with(1)->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("info")->once()->with("]");
+
+        $this->logger->info("INFO", [
+            "data"      =>  [
+                "field1"    =>  "One",
+                "field2"    =>  "Two",
+                "extra"     =>  ["Three", "Four"],
+            ],
         ]);
     }
 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+class LoggerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \League\CLImate\CLImate $cli
+     */
+    protected $cli;
+
+    /**
+     * @var \League\CLImate\Logger $logger
+     */
+    protected $logger;
+
+    public function setUp()
+    {
+        $this->cli = Mockery::mock('League\CLImate\CLImate');
+
+        $style = Mockery::mock('League\CLImate\Decorator\Style');
+        $style->shouldReceive("get")->andReturn(true);
+        $this->cli->style = $style;
+
+        $this->logger = new League\CLImate\Logger($this->cli);
+    }
+
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+
+    /** @test */
+    public function it_can_log_emergencies()
+    {
+        $this->cli->shouldReceive("emergency")->once()->with("Testing emergency");
+        $this->logger->emergency("Testing emergency");
+    }
+
+    /** @test */
+    public function it_can_log_alert()
+    {
+        $this->cli->shouldReceive("alert")->once()->with("Testing alert");
+        $this->logger->alert("Testing alert");
+    }
+
+    /** @test */
+    public function it_can_log_critically()
+    {
+        $this->cli->shouldReceive("critical")->once()->with("Testing critical");
+        $this->logger->critical("Testing critical");
+    }
+
+    /** @test */
+    public function it_can_log_errors()
+    {
+        $this->cli->shouldReceive("error")->once()->with("Testing error");
+        $this->logger->error("Testing error");
+    }
+
+    /** @test */
+    public function it_can_log_warnings()
+    {
+        $this->cli->shouldReceive("warning")->once()->with("Testing warning");
+        $this->logger->warning("Testing warning");
+    }
+
+    /** @test */
+    public function it_can_log_notices()
+    {
+        $this->cli->shouldReceive("notice")->once()->with("Testing notice");
+        $this->logger->notice("Testing notice");
+    }
+
+    /** @test */
+    public function it_can_log_info()
+    {
+        $this->cli->shouldReceive("info")->once()->with("Testing info");
+        $this->logger->info("Testing info");
+    }
+
+    /** @test */
+    public function it_can_log_debug()
+    {
+        $this->cli->shouldReceive("debug")->once()->with("Testing debug");
+        $this->logger->debug("Testing debug");
+    }
+
+    /** @test */
+    public function it_can_log_generically()
+    {
+        $this->cli->shouldReceive("critical")->once()->with("Testing log");
+        $this->logger->log("critical", "Testing log");
+    }
+
+    /** @test */
+    public function it_can_log_with_context()
+    {
+        $this->cli->shouldReceive("info")->once()->with("With context");
+        $this->cli->shouldReceive("tab")->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("info")->once()->with("context: CONTEXT");
+        $this->logger->info("With context", [
+            "context"   =>  "CONTEXT",
+        ]);
+    }
+
+    /** @test */
+    public function it_can_log_with_empty_context()
+    {
+        $this->cli->shouldReceive("info")->once()->with("No context");
+        $this->logger->info("No context", []);
+    }
+
+    /** @test */
+    public function it_can_log_with_placeholders()
+    {
+        $this->cli->shouldReceive("info")->once()->with("I am Spartacus!");
+        $this->logger->info("I am {username}!", [
+            "username"  =>  "Spartacus",
+        ]);
+    }
+
+    /** @test */
+    public function it_can_log_with_placeholders_and_context()
+    {
+        $this->cli->shouldReceive("info")->once()->with("I am Spartacus!");
+        $this->cli->shouldReceive("tab")->once()->andReturn($this->cli);
+        $this->cli->shouldReceive("info")->once()->with("date: 2015-03-01");
+        $this->logger->info("I am {username}!", [
+            "username"  =>  "Spartacus",
+            "date"      =>  "2015-03-01",
+        ]);
+    }
+}


### PR DESCRIPTION
Inspired by #57 I created a simple `Logger` class that implements the PSR-3 LoggerInterface.

Including some of the other features from:
https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md
* Objects with __toString()
* Exceptions in context
* Placeholders in context