### PR TITLE
Add multi-line input support

### DIFF
--- a/src/TerminalObject/Dynamic/Input.php
+++ b/src/TerminalObject/Dynamic/Input.php
@@ -22,6 +22,15 @@ class Input extends InputAbstract
     protected $strict = false;
 
     /**
+     * Whether to accept multiple lines of input
+     * 
+     * Terminated by ^D
+     * 
+     * @var boolean $multiLine
+     */
+    protected $multiLine = false;
+    
+    /**
      * Whether we should display the acceptable responses to the user
      *
      * @var boolean $show_acceptable
@@ -51,7 +60,9 @@ class Input extends InputAbstract
     {
         $this->writePrompt();
 
-        $response = $this->valueOrDefault($this->reader->line());
+        $input = (!$this->multiLine) ? $this->reader->line() : $this->reader->multiLine();
+        
+        $response = $this->valueOrDefault($input);
 
         if ($this->isValidResponse($response)) {
             return $response;
@@ -100,6 +111,13 @@ class Input extends InputAbstract
     {
         $this->default = $default;
 
+        return $this;
+    }
+    
+    public function multiLine()
+    {
+        $this->multiLine = true;
+        
         return $this;
     }
 

--- a/src/Util/Reader/ReaderInterface.php
+++ b/src/Util/Reader/ReaderInterface.php
@@ -9,4 +9,8 @@ interface ReaderInterface
      */
     public function line();
 
+    /**
+     * @return string
+     */
+    public function multiLine();
 }

--- a/src/Util/Reader/Stdin.php
+++ b/src/Util/Reader/Stdin.php
@@ -6,6 +6,8 @@ use Seld\CliPrompt\CliPrompt;
 
 class Stdin implements ReaderInterface
 {
+    protected $stdIn = false;
+    
     /**
      * Read the line typed in by the user
      *
@@ -13,8 +15,20 @@ class Stdin implements ReaderInterface
      */
     public function line()
     {
-        $response = trim(fgets(STDIN, 1024));
+        $response = trim(fgets($this->getStdIn(), 1024));
 
+        return $response;
+    }
+
+    /**
+     * Read from STDIN until EOF (^D) is reached
+     * 
+     * @return string
+     */
+    public function multiLine()
+    {
+        $response = trim(stream_get_contents($this->getStdIn()));
+        
         return $response;
     }
 
@@ -27,7 +41,7 @@ class Stdin implements ReaderInterface
      */
     public function char($count = 1)
     {
-        return fread(STDIN, $count);
+        return fread($this->getStdIn(), $count);
     }
 
     /**
@@ -40,4 +54,34 @@ class Stdin implements ReaderInterface
         return CliPrompt::hiddenPrompt();
     }
 
+    /**
+     * Return a valid STDIN, even if it previously EOF'ed
+     * 
+     * Lazily re-opens STDIN after hitting an EOF
+     * 
+     * @return resource
+     * @throws \Exception
+     */
+    protected function getStdIn()
+    {
+        if ($this->stdIn && !feof($this->stdIn)) {
+            return $this->stdIn;
+        }
+        
+        try {
+            if ($this->stdIn !== false) {
+                fclose($this->stdIn);
+            }
+            
+            $this->stdIn = fopen('php://stdin', 'r');
+
+            if (!$this->stdIn) {
+                throw new \Exception("Unable to read from STDIN");
+            }
+        } catch (\Error $e) {
+            throw new \Exception("Unable to read from STDIN", 0, $e);
+        }
+        
+        return $this->stdIn;
+    }
 }

--- a/tests/InputTest.php
+++ b/tests/InputTest.php
@@ -171,4 +171,35 @@ class InputTest extends TestBase
         $this->assertSame('Not much.', $response);
     }
 
+    /** @test */
+    public function it_will_accept_multiple_lines()
+    {
+        $this->shouldReadMultipleLinesAndReturn("Multiple\nLines\x04");
+        $this->shouldReceiveSameLine();
+        $this->shouldWrite("\e[m>>> \e[0m");
+        
+        $input = $this->cli->input('>>>', $this->reader);
+        $input->multiLine();
+        $response = $input->prompt();
+    }
+
+    /** @test */
+    public function it_will_read_after_eof()
+    {
+        $this->shouldReadMultipleLinesAndReturn("Multiple\nLines\x04");
+        $this->shouldReceiveSameLine();
+        $this->shouldWrite("\e[m>>> \e[0m");
+
+        $input = $this->cli->input('>>>', $this->reader);
+        $input->multiLine();
+        $response = $input->prompt();
+
+        $this->shouldReadMultipleLinesAndReturn("Multiple\nLines\nAgain\x04");
+        $this->shouldReceiveSameLine();
+        $this->shouldWrite("\e[m>>> \e[0m");
+
+        $input = $this->cli->input('>>>', $this->reader);
+        $input->multiLine();
+        $response = $input->prompt();
+    }
 }

--- a/tests/TestBase.php
+++ b/tests/TestBase.php
@@ -76,6 +76,16 @@ class TestBase extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Helper for reader mock
+     * 
+     * @param string $response
+     */
+    protected function shouldReadMultipleLinesAndReturn($response)
+    {
+        $this->reader->shouldReceive('multiLine')->once()->andReturn($response);
+    }
+
+    /**
      * Helper for same line output mock
      */
     protected function shouldReceiveSameLine()


### PR DESCRIPTION
This add the ability to read multiple lines of input terminated
by `^D` (`\x04` or EOT).

Additionally, this solves the issue where CLImate is unable to
read after `STDIN` hits an EOF by lazily creating a new `php://input`
stream as needed.

```php
$input = $this->cli->input('>>>', $this->reader);
$input->multiLine();
$response = $input->prompt(); // Will wait for ^D before returning
```