### PR TITLE
Add method to check whether Stty is available.

### DIFF
--- a/src/Util/System/System.php
+++ b/src/Util/System/System.php
@@ -65,4 +65,17 @@ abstract class System
 
         return exec($command);
     }
+
+    /**
+     * Returns whether Stty is available or not
+     * @see https://github.com/symfony/console/blob/master/Helper/QuestionHelper.php#L449-L463
+     *
+     * @return bool
+     */
+    public function hasSttyAvailable()
+    {
+        exec('stty 2>&1', $output, $exitcode);
+
+        return $exitcode === 0;
+    }
 }


### PR DESCRIPTION
First of all, I'm not CLI expert and this is just my personal use case, also my english is so poor but I'll do my best. :grin: 

Currently I have a [project](https://github.com/projek-xyz/ci-startapp) that use **climate** to nicely interact from CLI, including installation process. e.g. Asking your hostname, database host, database username etc. It works fine when I run the command directly from my terminal. But when I add the same command to Composer `post-create-project-cmd` hooks, I got errors that said

```
standard input: Inappropriate ioctl for device
```

I've also make a [video](https://www.youtube.com/watch?v=h8XpFuZV-YI) (indonesian language) to tell about this problem.

Finaly I found a method from [Symfony/Console](https://github.com/symfony/console/blob/master/Helper/QuestionHelper.php#L449-L463) component that could determine whether STTY is available or not. I just try to implement this on my projek-xyz/ci-console@babaa758 and it works.

Now I think it's would be great if climate have this feature built in.
