### PR TITLE
Refactoring "fileSearch" - Removed "glob" for usage in phar-archives

### DIFF
--- a/src/TerminalObject/Helper/Art.php
+++ b/src/TerminalObject/Helper/Art.php
@@ -102,8 +102,23 @@ trait Art
     protected function fileSearch($art, $pattern)
     {
         foreach ($this->art_dirs as $dir) {
-            // Look for anything that has the $art filename
-            $paths = glob($dir . '/' . $art . $pattern);
+            $directoryIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
+
+            $paths = array();
+            $regex = '~' . preg_quote($art) . $pattern . '~';
+
+            foreach ($directoryIterator as $file) {
+                if ($file->isDir()) {
+                    continue;
+                }
+
+                // Look for anything that has the $art filename
+                if (preg_match($regex, $file)) {
+                    $paths[] = $file->getPathname();
+                }
+            }
+
+            asort($paths);
 
             // If we've got one, no need to look any further
             if (!empty($paths)) {


### PR DESCRIPTION
The phar stream wrapper do not support glob (http://php.net/manual/de/phar.using.stream.php#104320), so I refactored the function "fileSearch" to use climate inside phar-archive.
