### PR TITLE
Add interfaces for support custom argument manager

### DIFF
--- a/src/Argument/Argument.php
+++ b/src/Argument/Argument.php
@@ -2,7 +2,7 @@
 
 namespace League\CLImate\Argument;
 
-class Argument
+class Argument implements ArgumentInterface
 {
     /**
      * An argument's name.
@@ -85,12 +85,7 @@ class Argument
     }
 
     /**
-     * Build a new command argument from an array.
-     *
-     * @param string $name
-     * @param array $params
-     *
-     * @return Argument
+     * {@inheritdoc}
      */
     public static function createFromArray($name, array $params)
     {

--- a/src/Argument/ArgumentInterface.php
+++ b/src/Argument/ArgumentInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace League\CLImate\Argument;
+
+interface ArgumentInterface
+{
+    /**
+     * Build a new command argument from an array.
+     *
+     * @param string $name
+     * @param array $params
+     *
+     * @return Argument
+     */
+    public static function createFromArray($name, array $params);
+}

--- a/src/Argument/Filter.php
+++ b/src/Argument/Filter.php
@@ -2,14 +2,12 @@
 
 namespace League\CLImate\Argument;
 
-class Filter
+class Filter implements FilterInterface
 {
     protected $arguments = [];
 
     /**
-     * Set the available arguments
-     *
-     * @param array $arguments
+     * {@inheritdoc}
      */
     public function setArguments(array $arguments)
     {
@@ -155,12 +153,12 @@ class Filter
      *
      * @see usort()
      *
-     * @param Argument $a
-     * @param Argument $b
+     * @param ArgumentInterface $a
+     * @param ArgumentInterface $b
      *
      * @return int
      */
-    public function compareByPrefix(Argument $a, Argument $b)
+    public function compareByPrefix(ArgumentInterface $a, ArgumentInterface $b)
     {
         if ($this->prefixCompareString($a) < $this->prefixCompareString($b)) {
             return -1;
@@ -172,11 +170,11 @@ class Filter
     /**
      * Prep the prefix string for comparison
      *
-     * @param Argument $argument
+     * @param ArgumentInterface $argument
      *
      * @return string
      */
-    protected function prefixCompareString(Argument $argument)
+    protected function prefixCompareString(ArgumentInterface $argument)
     {
         return strtolower($argument->longPrefix() ?: $argument->prefix() ?: '');
     }

--- a/src/Argument/FilterInterface.php
+++ b/src/Argument/FilterInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace League\CLImate\Argument;
+
+interface FilterInterface
+{
+    /**
+     * Set the available arguments
+     *
+     * @param array $arguments
+     */
+    public function setArguments(array $arguments);
+}

--- a/src/Argument/Manager.php
+++ b/src/Argument/Manager.php
@@ -59,7 +59,7 @@ class Manager implements ManagerInterface
         $this->filter  = $filter ?: new Filter();
         $this->summary = $summary ?: new Summary();
         $this->parser  = $parser ?: new Parser();
-        $this->creator = $creator ?: Argument::class;
+        $this->creator = $creator ?: 'League\CLImate\Argument\Argument';
         $reflection = new \ReflectionClass($this->creator);
         $implementsInterface = $reflection->implementsInterface(ArgumentInterface::class);
         if ($implementsInterface) {

--- a/src/Argument/Manager.php
+++ b/src/Argument/Manager.php
@@ -61,14 +61,14 @@ class Manager implements ManagerInterface
         $this->parser  = $parser ?: new Parser();
         $this->creator = $creator ?: 'League\CLImate\Argument\Argument';
         $reflection = new \ReflectionClass($this->creator);
-        $implementsInterface = $reflection->implementsInterface(ArgumentInterface::class);
+        $implementsInterface = $reflection->implementsInterface('\League\CLImate\Argument\ArgumentInterface');
         if ($implementsInterface) {
             $this->creator = $reflection->newInstanceWithoutConstructor();
         } else {
             throw new \InvalidArgumentException(sprintf(
                 'The given argument "%s" must be implements "%s".',
                 $this->creator,
-                ArgumentInterface::class
+                '\League\CLImate\Argument\ArgumentInterface'
             ));
         }
     }

--- a/src/Argument/ManagerInterface.php
+++ b/src/Argument/ManagerInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace League\CLImate\Argument;
+
+use League\CLImate\CLImate;
+
+interface ManagerInterface
+{
+    /**
+     * Add an argument.
+     *
+     * @throws \Exception if $argument isn't an array or Argument object.
+     * @param Argument|string|array $argument
+     * @param array $options
+     */
+    public function add($argument, array $options = []);
+
+    /**
+     * Determine if an argument exists.
+     *
+     * @param string $name
+     * @return bool
+     */
+    public function exists($name);
+
+    /**
+     * Retrieve an argument's value.
+     *
+     * @param string $name
+     * @return string|int|float|bool|null
+     */
+    public function get($name);
+
+    /**
+     * Retrieve all arguments.
+     *
+     * @return Argument[]
+     */
+    public function all();
+
+    /**
+     * Set a program's description.
+     *
+     * @param string $description
+     */
+    public function description($description);
+
+    /**
+     * Output a script's usage statement.
+     *
+     * @param CLImate $climate
+     * @param array $argv
+     */
+    public function usage(CLImate $climate, array $argv = null);
+}

--- a/src/Argument/Parser.php
+++ b/src/Argument/Parser.php
@@ -2,27 +2,30 @@
 
 namespace League\CLImate\Argument;
 
-class Parser
+class Parser implements ParserInterface
 {
     /**
      * Filter class to find various types of arguments
      *
-     * @var \League\CLImate\Argument\Filter $filter
+     * @var FilterInterface $filter
      */
     protected $filter;
 
     /**
      * Summary builder class
      *
-     * @var \League\CLImate\Argument\Summary $summary
+     * @var SummaryInterface $summary
      */
     protected $summary;
 
     protected $trailing;
 
-    public function __construct()
+    /**
+     * @param SummaryInterface $summary
+     */
+    public function __construct(SummaryInterface $summary = null)
     {
-        $this->summary = new Summary();
+        $this->summary = $summary ?: new Summary();
     }
 
     /**
@@ -31,7 +34,7 @@ class Parser
      *
      * @return \League\CLImate\Argument\Parser
      */
-    public function setFilter($filter, $arguments)
+    public function setFilter(FilterInterface $filter, $arguments)
     {
         $this->filter = $filter;
         $this->filter->setArguments($arguments);
@@ -40,10 +43,7 @@ class Parser
     }
 
     /**
-     * Parse command line arguments into CLImate arguments.
-     *
-     * @throws \Exception if required arguments aren't defined.
-     * @param array $argv
+     * {@inheritdoc}
      */
     public function parse(array $argv = null)
     {

--- a/src/Argument/ParserInterface.php
+++ b/src/Argument/ParserInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace League\CLImate\Argument;
+
+interface ParserInterface
+{
+    /**
+     * Parse command line arguments into CLImate arguments.
+     *
+     * @throws \Exception if required arguments aren't defined.
+     * @param array $argv
+     */
+    public function parse(array $argv = null);
+}

--- a/src/Argument/Summary.php
+++ b/src/Argument/Summary.php
@@ -4,7 +4,7 @@ namespace League\CLImate\Argument;
 
 use League\CLImate\CLImate;
 
-class Summary
+class Summary implements SummaryInterface
 {
     /**
      * @var \League\CLImate\CLImate $climate
@@ -77,7 +77,7 @@ class Summary
     }
 
     /**
-     * Output the full summary for the program
+     * {@inheritdoc}
      */
     public function output()
     {
@@ -114,11 +114,11 @@ class Summary
      * For example, "-u username, --user username", "--force", or
      * "-c count (default: 7)".
      *
-     * @param Argument $argument
+     * @param ArgumentInterface $argument
      *
      * @return string
      */
-    public function argument(Argument $argument)
+    public function argument(ArgumentInterface $argument)
     {
         $summary     = $this->prefixedArguments($argument);
         $printedName = strstr($summary, ' ' . $argument->name());
@@ -138,11 +138,11 @@ class Summary
     /**
      * Build argument summary surrounded by brackets
      *
-     * @param Argument $argument
+     * @param ArgumentInterface $argument
      *
      * @return string
      */
-    protected function argumentBracketed(Argument $argument)
+    protected function argumentBracketed(ArgumentInterface $argument)
     {
         return '[' . $this->argument($argument) . ']';
     }
@@ -183,11 +183,11 @@ class Summary
     /**
      * Builds the summary for any prefixed arguments
      *
-     * @param Argument $argument
+     * @param ArgumentInterface $argument
      *
      * @return string
      */
-    protected function prefixedArguments(Argument $argument)
+    protected function prefixedArguments(ArgumentInterface $argument)
     {
         $prefixes = [$argument->prefix(), $argument->longPrefix()];
         $summary  = [];

--- a/src/Argument/SummaryInterface.php
+++ b/src/Argument/SummaryInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace League\CLImate\Argument;
+
+interface SummaryInterface
+{
+    /**
+     * Output the full summary for the program
+     */
+    public function output();
+}

--- a/src/CLImate.php
+++ b/src/CLImate.php
@@ -3,6 +3,7 @@
 namespace League\CLImate;
 
 use League\CLImate\Argument\Manager as ArgumentManager;
+use League\CLImate\Argument\ManagerInterface as ArgumentManagerInterface;
 use League\CLImate\Decorator\Style;
 use League\CLImate\Settings\Manager as SettingsManager;
 use League\CLImate\TerminalObject\Router\Router;
@@ -125,14 +126,14 @@ class CLImate
      */
     protected $util;
 
-    public function __construct()
+    public function __construct(ArgumentManagerInterface $argument = null)
     {
         $this->setStyle(new Style());
         $this->setRouter(new Router());
         $this->setSettingsManager(new SettingsManager());
         $this->setOutput(new Output());
         $this->setUtil(new UtilFactory());
-        $this->setArgumentManager(new ArgumentManager());
+        $this->setArgumentManager($argument ?: new ArgumentManager());
     }
 
     /**
@@ -168,9 +169,9 @@ class CLImate
     /**
      * Set the arguments property
      *
-     * @param \League\CLImate\Argument\Manager $manager
+     * @param \League\CLImate\Argument\ManagerInterface $manager
      */
-    public function setArgumentManager(ArgumentManager $manager)
+    public function setArgumentManager(ArgumentManagerInterface $manager)
     {
         $this->arguments = $manager;
     }


### PR DESCRIPTION
Example:

```
$climate = new League\CLImate\CLImate(new \Vendor\Argument\Manager());
```

or

```
$climate = new League\CLImate\CLImate();
$climate->setArgumentManager(new \Vendor\Argument\Manager());
```
