### PR TITLE
Ensure 2 empty lines are added when working with labels

### DIFF
--- a/src/TerminalObject/Dynamic/Progress.php
+++ b/src/TerminalObject/Dynamic/Progress.php
@@ -156,9 +156,12 @@ class Progress extends DynamicTerminalObject
     protected function getProgressBar($current, $label)
     {
         if ($this->first_line) {
-            // Drop down a line, we are about to
-            // re-write this line for the progress bar
+            // Drop down a line (or 2 if we have a label),
+            // we are about to re-write for the progress bar
             $this->output->write('');
+            if (strlen($label) > 0) {
+                $this->output->write('');
+            }
             $this->first_line = false;
         }
 

--- a/tests/ProgressTest.php
+++ b/tests/ProgressTest.php
@@ -80,6 +80,7 @@ class ProgressTest extends TestBase
     public function it_can_output_a_progress_bar_with_current_labels()
     {
         $this->shouldWrite('');
+        $this->shouldWrite('');
         $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(0)} 0%\n\r\e[Kzeroth\e[0m");
         $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(10)} 10%\n\r\e[Kfirst\e[0m");
         $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(20)} 20%\n\r\e[Ksecond\e[0m");
@@ -214,6 +215,7 @@ class ProgressTest extends TestBase
     /** @test */
     public function it_can_output_a_progress_bar_using_increments_with_label()
     {
+        $this->shouldWrite('');
         $this->shouldWrite('');
         $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(10)} 10%\n\r\e[Kstart\e[0m");
         $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(20)} 20%\n\r\e[Knext\e[0m");


### PR DESCRIPTION
When using labels with a progress bar 2 lines are used, and therefore 2 lines are required to be added when a progress bar is first created.

Fixes #94 
