### PR TITLE
Allow labels to be shown/hidden on each iteration

### DIFF
--- a/src/TerminalObject/Dynamic/Progress.php
+++ b/src/TerminalObject/Dynamic/Progress.php
@@ -54,6 +54,13 @@ class Progress extends DynamicTerminalObject
     protected $force_redraw = false;
 
     /**
+     * If this progress bar ever displayed a label.
+     *
+     * @var boolean $has_label_line
+     */
+    protected $has_label_line = false;
+
+    /**
      * If they pass in a total, set the total
      *
      * @param integer $total
@@ -162,13 +169,18 @@ class Progress extends DynamicTerminalObject
             $this->first_line = false;
         }
 
-        // Move the cursor up one line and clear it to the end
-        $line_count    = (strlen($label) > 0) ? 2 : 1;
+        // Move the cursor up and clear it to the end
+        $line_count = $this->has_label_line ? 2 : 1;
 
         $progress_bar  = $this->util->cursor->up($line_count);
         $progress_bar .= $this->util->cursor->startOfCurrentLine();
         $progress_bar .= $this->util->cursor->deleteCurrentLine();
         $progress_bar .= $this->getProgressBarStr($current, $label);
+
+        // If this line has a label then set that this progress bar has a label line
+        if (strlen($label) > 0) {
+            $this->has_label_line = true;
+        }
 
         return $progress_bar;
     }
@@ -192,6 +204,10 @@ class Progress extends DynamicTerminalObject
 
         if ($label) {
             $label = $this->labelFormatted($label);
+        // If this line doesn't have a label, but we've had one before,
+        // then ensure the label line is cleared
+        } elseif ($this->has_label_line) {
+            $label = $this->labelFormatted('');
         }
 
         return trim("{$bar} {$number}{$label}");

--- a/tests/ProgressTest.php
+++ b/tests/ProgressTest.php
@@ -80,7 +80,7 @@ class ProgressTest extends TestBase
     public function it_can_output_a_progress_bar_with_current_labels()
     {
         $this->shouldWrite('');
-        $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(0)} 0%\n\r\e[Kzeroth\e[0m");
+        $this->shouldWrite("\e[m\e[1A\r\e[K{$this->repeat(0)} 0%\n\r\e[Kzeroth\e[0m");
         $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(10)} 10%\n\r\e[Kfirst\e[0m");
         $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(20)} 20%\n\r\e[Ksecond\e[0m");
         $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(30)} 30%\n\r\e[Kthird\e[0m");
@@ -109,6 +109,29 @@ class ProgressTest extends TestBase
         ];
 
         for ($i = 0; $i <= 10; $i++) {
+            $progress->current($i, $labels[$i]);
+        }
+    }
+
+    /** @test */
+    public function it_can_output_a_progress_bar_with_current_optional_labels()
+    {
+        $this->shouldWrite('');
+        $this->shouldWrite("\e[m\e[1A\r\e[K{$this->repeat(0)} 0%\n\r\e[Kzeroth\e[0m");
+        $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(10)} 10%\n\r\e[K\e[0m");
+        $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(20)} 20%\n\r\e[Ksecond\e[0m");
+        $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(30)} 30%\n\r\e[Kthird\e[0m");
+
+        $progress = $this->cli->progress(10);
+
+        $labels = [
+            'zeroth',
+            '',
+            'second',
+            'third',
+        ];
+
+        for ($i = 0; $i <= 3; $i++) {
             $progress->current($i, $labels[$i]);
         }
     }
@@ -215,7 +238,7 @@ class ProgressTest extends TestBase
     public function it_can_output_a_progress_bar_using_increments_with_label()
     {
         $this->shouldWrite('');
-        $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(10)} 10%\n\r\e[Kstart\e[0m");
+        $this->shouldWrite("\e[m\e[1A\r\e[K{$this->repeat(10)} 10%\n\r\e[Kstart\e[0m");
         $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(20)} 20%\n\r\e[Knext\e[0m");
         $this->shouldWrite("\e[m\e[2A\r\e[K{$this->repeat(100)} 100%\n\r\e[Kfinal\e[0m");
 


### PR DESCRIPTION
While working on #97 I noticed that weird things happen if you aren't consistent with labels. The current code expects that either every iteration of a progress bar has a label, or none of them do.

I'm not sure if this was intended behaviour or not. But this pr allows labels to be added/removed on demand, and ensures that if a label had ever been added before, then it will be cleared if none is provided on future iterations.

Example test script to demonstrate the issue:

``` php
$climate->out('Output before progress bar.');
$progress = $climate->progress()->total(100);
for ($i = 0; $i <= 50; $i++) {
    $progress->current($i, "label for nr. $i");
    usleep(20000);
}
for ($i = 51; $i <= 100; $i++) {
    $progress->current($i);
    usleep(20000);
}
$climate->out('Output after progress bar.');
```
