### PR TITLE
Drop support for HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 env:
   - COMPOSER_OPTS=""

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The following versions of PHP are supported by this version.
 + PHP 5.4
 + PHP 5.5
 + PHP 5.6
++ PHP 7.0
++ PHP 7.1
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ The following versions of PHP are supported by this version.
 + PHP 5.4
 + PHP 5.5
 + PHP 5.6
-+ HHVM
 
 ## Documentation
 


### PR DESCRIPTION
It looks like the build is currently failing on HHVM, and there's been a shift in the PHP community recently to drop support for HHVM now that PHP 7 has reduced the performance gains offered by HHVM.

Also a minor update to the readme to ensure the supported versions listed are accurate