### PR TITLE
Fix to static resources on HTTPS version

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,7 +27,7 @@
 <body>
 
 <section class="all_packages">
-    <a href="http://thephpleague.com/">
+    <a href="https://thephpleague.com/">
         <img src="https://theme.thephpleague.com/img/loep_logo.png" width="195" height="200" alt="The League of Extraordinary Packages">
     </a>
     <h2>Our Packages:</h2>
@@ -46,7 +46,7 @@
         <span class="name">{{ site.data.project.title }}</span>
         <span class="tagline">{{ site.data.project.tagline }}</span>
     </a>
-    <a href="http://thephpleague.com/" class="league">
+    <a href="https://thephpleague.com/" class="league">
         Presented by The League of Extraordinary Packages
     </a>
 </header>
@@ -76,8 +76,8 @@
 </main>
 
 <footer>
-    <span>&copy; Copyright <a href="http://thephpleague.com">The League of Extraordinary Packages</a>.</span>
-    <span>Site design by <a href="http://reinink.ca">Jonathan Reinink</a>.</span>
+    <span>&copy; Copyright <a href="https://thephpleague.com">The League of Extraordinary Packages</a>.</span>
+    <span>Site design by <a href="https://reinink.ca">Jonathan Reinink</a>.</span>
 </footer>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,20 +15,20 @@
     {% if site.data.images.favicon %}
         <link rel="icon" type="image/x-icon" href="{{ site.data.images.favicon }}" />
     {% else %}
-        <link rel="icon" type="image/x-icon" href="http://theme.thephpleague.com/img/favicon.ico" />
+        <link rel="icon" type="image/x-icon" href="https://theme.thephpleague.com/img/favicon.ico" />
     {% endif %}
     {% if site.data.images.apple_touch %}
         <link rel="apple-touch-icon-precomposed" href="{{ site.data.images.apple_touch }}">
     {% else %}
-        <link rel="apple-touch-icon-precomposed" href="http://theme.thephpleague.com/img/apple-touch-icon-precomposed.png">
+        <link rel="apple-touch-icon-precomposed" href="https://theme.thephpleague.com/img/apple-touch-icon-precomposed.png">
     {% endif %}
-    <link rel="stylesheet" href="http://theme.thephpleague.com/css/all.css">
+    <link rel="stylesheet" href="https://theme.thephpleague.com/css/all.css">
 </head>
 <body>
 
 <section class="all_packages">
     <a href="http://thephpleague.com/">
-        <img src="http://theme.thephpleague.com/img/loep_logo.png" width="195" height="200" alt="The League of Extraordinary Packages">
+        <img src="https://theme.thephpleague.com/img/loep_logo.png" width="195" height="200" alt="The League of Extraordinary Packages">
     </a>
     <h2>Our Packages:</h2>
     <ul>
@@ -80,9 +80,9 @@
     <span>Site design by <a href="http://reinink.ca">Jonathan Reinink</a>.</span>
 </footer>
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
-<script src="http://theme.thephpleague.com/js/scripts.js"></script>
-<script src="http://theme.thephpleague.com/js/prism.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+<script src="https://theme.thephpleague.com/js/scripts.js"></script>
+<script src="https://theme.thephpleague.com/js/prism.js"></script>
 
 {% if site.data.project.google_analytics_tracking_id %}
     <script>


### PR DESCRIPTION
The https version of the documentation [is indexed](https://www.dropbox.com/s/vabwfvrfokbf238/Screenshot%202017-06-23%2015.23.53.png?dl=0), and since the references are pointing to http, the site looks broken.