### PR TITLE
Add support for parsing multiply passed args

### DIFF
--- a/src/Argument/Argument.php
+++ b/src/Argument/Argument.php
@@ -65,14 +65,14 @@ class Argument
      *
      * @var string
      */
-    protected $defaultValue;
+    protected $defaultValue = [];
 
     /**
      * An argument's value, after type casting.
      *
-     * @var string|int|float|bool
+     * @var string[]|int[]|float[]|bool[]
      */
-    protected $value;
+    protected $values = [];
 
     /**
      * Build a new command argument.
@@ -100,10 +100,6 @@ class Argument
         foreach ($params as $key => $value) {
             $method = 'set' . ucwords($key);
             $argument->{$method}($value);
-        }
-
-        if ($argument->defaultValue()) {
-            $argument->setValue($argument->defaultValue());
         }
 
         return $argument;
@@ -298,7 +294,7 @@ class Argument
     }
 
     /**
-     * Retrieve an argument's default value.
+     * Retrieve an argument's default values.
      *
      * @return string
      */
@@ -314,7 +310,7 @@ class Argument
      */
     public function setDefaultValue($defaultValue)
     {
-        $this->defaultValue = $defaultValue;
+        $this->defaultValue = (array) $defaultValue;
     }
 
     /**
@@ -326,7 +322,27 @@ class Argument
      */
     public function value()
     {
-        return $this->value;
+        if ($this->values) {
+            return end($this->values);
+        }
+        $cast_method = 'castTo' . ucwords($this->castTo);
+        return $this->{$cast_method}(current($this->defaultValue()));
+    }
+
+    /**
+     * Retrieve an argument's value.
+     *
+     * Argument values are type cast based on the value of $castTo.
+     *
+     * @return string[]|int[]|float[]|bool[]
+     */
+    public function valueArray()
+    {
+        if ($this->values) {
+            return $this->values;
+        }
+        $cast_method = 'castTo' . ucwords($this->castTo);
+        return array_map([$this, $cast_method], $this->defaultValue());
     }
 
     /**
@@ -339,7 +355,7 @@ class Argument
     public function setValue($value)
     {
         $cast_method = 'castTo' . ucwords($this->castTo);
-        $this->value = $this->{$cast_method}($value);
+        $this->values[] = $this->{$cast_method}($value);
     }
 
     /**

--- a/src/Argument/Filter.php
+++ b/src/Argument/Filter.php
@@ -147,7 +147,7 @@ class Filter
      */
     protected function noValue($argument)
     {
-        return is_null($argument->value());
+        return $argument->valueArray() == [];
     }
 
     /**

--- a/src/Argument/Manager.php
+++ b/src/Argument/Manager.php
@@ -108,6 +108,17 @@ class Manager
     }
 
     /**
+     * Retrieve an argument's all values as an array.
+     *
+     * @param string $name
+     * @return string[]|int[]|float[]|bool[]
+     */
+    public function getArray($name)
+    {
+        return isset($this->arguments[$name]) ? $this->arguments[$name]->valueArray() : [];
+    }
+
+    /**
      * Retrieve all arguments.
      *
      * @return Argument[]

--- a/src/Argument/Summary.php
+++ b/src/Argument/Summary.php
@@ -128,8 +128,12 @@ class Summary
             $summary .= $argument->name();
         }
 
-        if ($argument->defaultValue()) {
-            $summary .= " (default: {$argument->defaultValue()})";
+        if ($defaults = $argument->defaultValue()) {
+            if (count($defaults) == 1) {
+                $summary .= " (default: {$defaults[0]})";
+            } else {
+                $summary .= ' (defaults: ' . implode(', ', $defaults) . ')';
+            }
         }
 
         return $summary;

--- a/tests/ArgumentTest.php
+++ b/tests/ArgumentTest.php
@@ -75,6 +75,11 @@ class ArgumentTest extends TestBase
                 'description'  => 'Has a default value',
                 'defaultValue' => 'test',
             ],
+            'default-value2' => [
+                'prefix'       => 'x',
+                'description'  => 'Has also a default value',
+                'defaultValue' => ['test2', 'test3'],
+            ],
         ];
     }
 
@@ -109,7 +114,7 @@ class ArgumentTest extends TestBase
     {
         // Test Description
         //
-        // Usage: test-script [-b both-prefixes, --both both-prefixes] [-d, --defined] [--long only-long-prefix] [-r required] [-s only-short-prefix] [-v default-value (default: test)] [no-prefix]
+        // Usage: test-script [-b both-prefixes, --both both-prefixes] [-d, --defined] [--long only-long-prefix] [-r required] [-s only-short-prefix] [-v default-value (default: test)] [-x default-value2 (defaults: test2, test3)] [no-prefix]
         //
         // Required Arguments:
         //     -r required
@@ -126,6 +131,8 @@ class ArgumentTest extends TestBase
         //         Only long prefix
         //     -v default-value (default: test)
         //         Has a default value
+        //     -x default-value2 (defaults: test2, test3)
+        //         Has also a default value
         //     no-prefix
         //         Not defined by a prefix
 
@@ -135,7 +142,7 @@ class ArgumentTest extends TestBase
         $this->shouldWrite("\e[mUsage: test-script "
                             . "[-b both-prefixes, --both both-prefixes] [-d, --defined] "
                             . "[--long only-long-prefix] [-r required] [-s only-short-prefix] "
-                            . "[-v default-value (default: test)] [no-prefix]\e[0m");
+                            . "[-v default-value (default: test)] [-x default-value2 (defaults: test2, test3)] [no-prefix]\e[0m");
 
         $this->shouldWrite("\e[m\e[0m");
         $this->shouldWrite("\e[mRequired Arguments:\e[0m");
@@ -174,10 +181,15 @@ class ArgumentTest extends TestBase
         $this->shouldWrite("\e[mHas a default value\e[0m");
 
         $this->shouldWrite("\e[m\t\e[0m");
+        $this->shouldWrite("\e[m-x default-value2 (defaults: test2, test3)\e[0m");
+        $this->shouldWrite("\e[m\t\t\e[0m");
+        $this->shouldWrite("\e[mHas also a default value\e[0m");
+
+        $this->shouldWrite("\e[m\t\e[0m");
         $this->shouldWrite("\e[mno-prefix\e[0m");
         $this->shouldWrite("\e[m\t\t\e[0m");
         $this->shouldWrite("\e[mNot defined by a prefix\e[0m");
-        $this->shouldHavePersisted(35);
+        $this->shouldHavePersisted(39);
 
         $this->cli->description('Test Description');
         $this->cli->arguments->add($this->getFullArguments());
@@ -213,6 +225,7 @@ class ArgumentTest extends TestBase
 
         $argv = [
             'test-script',
+            '-s=baz',
             '-s',
             'foo',
             '--long',
@@ -236,6 +249,7 @@ class ArgumentTest extends TestBase
         $this->assertEquals('no_prefix_value', $processed['no-prefix']);
         $this->assertTrue($processed['defined-only']);
         $this->assertEquals('foo', $this->cli->arguments->get('only-short-prefix'));
+        $this->assertEquals(['baz', 'foo'], $this->cli->arguments->getArray('only-short-prefix'));
     }
 
     /** @test */


### PR DESCRIPTION
This essentially allows parsing multiple arguments with the same identifier.

For example `bin/myapp -d foo=bar -d baz=qux` would be parseable via `$climate->arguments->getArray("d")` and return `["foo=bar", "baz=qux"]`.

This is in general much more friendly than having to comma separate an options list or such like `bin/myapp -d foo=bar,baz=qux`, which typically needs more complicated handling to also assemble the options when passing them programmatically.

For backwards compatibility, the behavior of `get()` is fully retained, it will still return the argument which was passed last. Apart from the internal Argument class, nothing should have changed with regards to BC.