### PR TITLE
added the each method to the progress class

### DIFF
--- a/src/TerminalObject/Dynamic/Progress.php
+++ b/src/TerminalObject/Dynamic/Progress.php
@@ -128,6 +128,24 @@ class Progress extends DynamicTerminalObject
     }
 
     /**
+     * Loop through the data and self manage the progress bar advancement
+     *
+     * @param mixed $data Array or any other iterable object
+     * @param callable $callback
+     */
+    public function each($data, callable $callback)
+    {
+        if (!$this->total) {
+            $this->total(count($data));
+        }
+
+        foreach ($data as $item) {
+            $callback($item);
+            $this->advance();
+        }
+    }
+
+    /**
      * Draw the progress bar, if necessary
      *
      * @param string $current

--- a/tests/ProgressTest.php
+++ b/tests/ProgressTest.php
@@ -267,4 +267,24 @@ class ProgressTest extends TestBase
             $progress->current($item);
         }
     }
+
+    /** @test */
+    public function it_can_self_manage_progress_bar_while_looping()
+    {
+        $this->shouldWrite('');
+        $this->shouldWrite("\e[m\e[1A\r\e[K{$this->repeat(10)} 10%\e[0m");
+        $this->shouldWrite("\e[m\e[1A\r\e[K{$this->repeat(20)} 20%\e[0m");
+        $this->shouldWrite("\e[m\e[1A\r\e[K{$this->repeat(30)} 30%\e[0m");
+        $this->shouldWrite("\e[m\e[1A\r\e[K{$this->repeat(40)} 40%\e[0m");
+        $this->shouldWrite("\e[m\e[1A\r\e[K{$this->repeat(50)} 50%\e[0m");
+        $this->shouldWrite("\e[m\e[1A\r\e[K{$this->repeat(60)} 60%\e[0m");
+        $this->shouldWrite("\e[m\e[1A\r\e[K{$this->repeat(70)} 70%\e[0m");
+        $this->shouldWrite("\e[m\e[1A\r\e[K{$this->repeat(80)} 80%\e[0m");
+        $this->shouldWrite("\e[m\e[1A\r\e[K{$this->repeat(90)} 90%\e[0m");
+        $this->shouldWrite("\e[m\e[1A\r\e[K{$this->repeat(100)} 100%\e[0m");
+
+        $this->cli->progress()->each(range(1, 10), function ($item) {
+            return true;
+        });
+    }
 }


### PR DESCRIPTION
Problem: I needed to constantly repeat and lookup the same boilerplate to have a progress bar on simple loops. 

Solution: I have added some shortcut functionality to the Progress Terminal Object to be able to draw a progress bar for a loop while reducing the amount of overhead.

```
// Before

$superheroes = ['batman', 'superman', 'aquaman'];

$progress = new \CLImate::progress();
$progress->total(count($superheroes));

foreach ($superheroes as $superhero) {
  echo "{$superhero} saves the day";
  $progress->advance();
}


---

//After

$superheroes = ['batman', 'superman', 'aquaman'];

\CLImate::progress()->each($superheroes, function ($superhero) {
  echo "{$superhero} saves the day";
});


