### PR TITLE
Add JSON_UNESCAPED_SLASHES to json_encode

### DIFF
--- a/src/TerminalObject/Basic/Json.php
+++ b/src/TerminalObject/Basic/Json.php
@@ -23,6 +23,6 @@ class Json extends BasicTerminalObject
      */
     public function result()
     {
-        return json_encode($this->data, JSON_PRETTY_PRINT);
+        return json_encode($this->data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     }
 }


### PR DESCRIPTION
No need to escape slashes in JSON data outputs as we're not dealing with HTML.