### PR TITLE
[Enhancement] Improved the confirmation dialog

### DIFF
--- a/src/TerminalObject/Dynamic/Confirm.php
+++ b/src/TerminalObject/Dynamic/Confirm.php
@@ -15,7 +15,7 @@ class Confirm extends Input
 
         $this->accept(['y', 'yes', 'n', 'no'], false);
 
-        $response = $this->prompt();
+        $response = \strtolower($this->prompt());
         return (substr($response, 0, 1) === 'y');
     }
 }

--- a/src/TerminalObject/Dynamic/Confirm.php
+++ b/src/TerminalObject/Dynamic/Confirm.php
@@ -11,9 +11,11 @@ class Confirm extends Input
      */
     public function confirmed()
     {
-        $this->accept(['y', 'n'], true);
-        $this->strict();
+        $this->prompt = $this->prompt . ' [y/n]';
 
-        return ($this->prompt() == 'y');
+        $this->accept(['y', 'yes', 'n', 'no'], false);
+
+        $response = $this->prompt();
+        return (substr($response, 0, 1) === 'y');
     }
 }

--- a/tests/ConfirmTest.php
+++ b/tests/ConfirmTest.php
@@ -31,17 +31,4 @@ class ConfirmTest extends TestBase
 
         $this->assertFalse($response);
     }
-
-    /** @test */
-    public function it_will_only_allow_strict_confirmations()
-    {
-        $this->shouldReadAndReturn('Y');
-        $this->shouldReadAndReturn('y');
-        $this->shouldReceiveSameLine();
-        $this->shouldWrite("\e[mKeep going? [y/n] \e[0m", 2);
-
-        $input = $this->cli->confirm('Keep going?', $this->reader);
-
-        $input->confirmed();
-    }
 }


### PR DESCRIPTION
Changed the behaviour of `confirm(...)` to accept more answers.
The following answers would now be considered valid:
- y
- n
- yes
- no
- Y
- N
- YES
- NO