### PR TITLE
Radio system improvement

### DIFF
--- a/src/TerminalObject/Dynamic/Radio.php
+++ b/src/TerminalObject/Dynamic/Radio.php
@@ -15,4 +15,40 @@ class Radio extends Checkboxes
     {
         return new Checkbox\RadioGroup($options);
     }
+
+    /**
+     * Take the appropriate action based on the input character,
+     * returns whether to stop listening or not
+     *
+     * @param string $char
+     *
+     * @return bool
+     */
+    protected function handleCharacter($char)
+    {
+        switch ($char) {
+            case ' ':
+            case "\n":
+                $this->checkboxes->toggleCurrent();
+                $this->output->sameLine()->write($this->util->cursor->defaultStyle());
+                $this->output->sameLine()->write("\e[0m");
+                return true; // Break the while loop as well
+
+            case "\e":
+                $this->handleAnsi();
+                break;
+        }
+
+        return false;
+    }
+
+    /**
+     * Format the prompt string
+     *
+     * @return string
+     */
+    protected function promptFormatted()
+    {
+        return $this->prompt . ' (press <Enter> to select)';
+    }
 }

--- a/tests/RadioTest.php
+++ b/tests/RadioTest.php
@@ -19,16 +19,12 @@ class RadioTest extends TestBase
     /** @test */
     public function it_will_select_only_one_item()
     {
-        // Select the first one
-        $this->shouldReadCharAndReturn(' ');
         // Go down one
         $this->shouldReadCharAndReturn("\e");
         $this->shouldReadCharAndReturn("[B", 2);
         // Go down one
         $this->shouldReadCharAndReturn("\e");
         $this->shouldReadCharAndReturn("[B", 2);
-        // Select the third one
-        $this->shouldReadCharAndReturn(' ');
         // Confirm entry
         $this->shouldReadCharAndReturn("\n");
 
@@ -40,6 +36,22 @@ class RadioTest extends TestBase
 
         $this->util->system->shouldReceive('exec')->with('stty -icanon');
         $this->util->system->shouldReceive('exec')->with('stty sane');
+
+        $this->shouldHideCursor();
+
+        $this->shouldReceiveSameLine();
+        $this->shouldWrite("\e[2A\r", 2);
+
+        $this->shouldReceiveSameLine();
+        $this->shouldWrite("\e[m  ○ Happy" . str_repeat(' ', 71) . "\e[0m", 2);
+        $this->shouldWrite("\e[m❯ ○ Sad" . str_repeat(' ', 73) . "\e[0m");
+        $this->shouldWrite("\e[m  ○ Thrilled" . str_repeat(' ', 68) . "\e[10D\e[8m\e[0m");
+
+        $this->shouldReceiveSameLine();
+        $this->shouldWrite("\e[m  ○ Sad" . str_repeat(' ', 73) . "\e[0m");
+        $this->shouldWrite("\e[m❯ ○ Thrilled" . str_repeat(' ', 68) . "\e[10D\e[8m\e[0m");
+
+        $this->shouldShowCursor();
 
         $this->shouldReceiveSameLine();
         $this->shouldWrite("\e[0m");

--- a/tests/RadioTest.php
+++ b/tests/RadioTest.php
@@ -32,7 +32,7 @@ class RadioTest extends TestBase
         // Confirm entry
         $this->shouldReadCharAndReturn("\n");
 
-        $this->shouldWrite("\e[mCurrent mood: (use <space> to select)\e[0m");
+        $this->shouldWrite("\e[mCurrent mood: (press <Enter> to select)\e[0m");
         $this->shouldWrite("\e[m❯ ○ Happy" . str_repeat(' ', 71) . "\e[0m");
         $this->shouldWrite("\e[m  ○ Sad" . str_repeat(' ', 73) . "\e[0m");
         $this->shouldReceiveSameLine();
@@ -40,28 +40,6 @@ class RadioTest extends TestBase
 
         $this->util->system->shouldReceive('exec')->with('stty -icanon');
         $this->util->system->shouldReceive('exec')->with('stty sane');
-        $this->shouldHideCursor();
-
-        $this->shouldReceiveSameLine();
-        $this->shouldWrite("\e[2A\r", 4);
-
-        $this->shouldWrite("\e[m❯ ● Happy" . str_repeat(' ', 71) . "\e[0m");
-        $this->shouldWrite("\e[m  ○ Sad" . str_repeat(' ', 73) . "\e[0m", 3);
-        $this->shouldReceiveSameLine();
-        $this->shouldWrite("\e[m  ○ Thrilled" . str_repeat(' ', 68) . "\e[10D\e[8m\e[0m", 2);
-
-        $this->shouldWrite("\e[m  ● Happy" . str_repeat(' ', 71) . "\e[0m", 2);
-        $this->shouldWrite("\e[m❯ ○ Sad" . str_repeat(' ', 73) . "\e[0m");
-        $this->shouldReceiveSameLine();
-
-        $this->shouldReceiveSameLine();
-        $this->shouldWrite("\e[m❯ ○ Thrilled" . str_repeat(' ', 68) . "\e[10D\e[8m\e[0m");
-
-        $this->shouldReceiveSameLine();
-        $this->shouldWrite("\e[m  ○ Happy" . str_repeat(' ', 71) . "\e[0m");
-        $this->shouldWrite("\e[m❯ ● Thrilled" . str_repeat(' ', 68) . "\e[10D\e[8m\e[0m");
-
-        $this->shouldShowCursor();
 
         $this->shouldReceiveSameLine();
         $this->shouldWrite("\e[0m");


### PR DESCRIPTION
This commit let you press "Enter" directly to select an option. Just overriding "handleCharacter" and "promptFormatted" so you don't have to press "Space" _then_ "Enter".