### PR TITLE
Fix wrong regex

### DIFF
--- a/src/TerminalObject/Helper/Art.php
+++ b/src/TerminalObject/Helper/Art.php
@@ -87,7 +87,7 @@ trait Art
      */
     protected function artFile($art)
     {
-        $files = $this->fileSearch($art, '[^' . \DIRECTORY_SEPARATOR . ']*$');
+        $files = $this->fileSearch($art, '[^' . '\\' . DIRECTORY_SEPARATOR . ']*$');
 
         if (count($files) === 0) {
             $this->addDir(__DIR__ . '/../../ASCII');


### PR DESCRIPTION
Regex error when executing on Windows OS, produce an error message 'Warning: preg_match(): Compilation failed: missing terminating ] for character class at offset 12 in ..\vendor\league\climate\src\TerminalObject\Helper\Art.php on line 127'