### PR TITLE
Addressed file searching issues when the directory separator was a backslash

### DIFF
--- a/src/TerminalObject/Helper/Art.php
+++ b/src/TerminalObject/Helper/Art.php
@@ -28,6 +28,13 @@ trait Art
     protected $art = '';
 
     /**
+     * The directory separator
+     *
+     * @var string $directory_separator
+     */
+    public $directory_separator = \DIRECTORY_SEPARATOR;
+
+    /**
      * Specify which settings Draw needs to import
      *
      * @return array
@@ -87,7 +94,7 @@ trait Art
      */
     protected function artFile($art)
     {
-        $files = $this->fileSearch($art, '[^' . \DIRECTORY_SEPARATOR . ']*$');
+        $files = $this->fileSearch($art, '[^' . $this->directory_separator . ']*$');
 
         if (count($files) === 0) {
             $this->addDir(__DIR__ . '/../../ASCII');

--- a/src/TerminalObject/Helper/Art.php
+++ b/src/TerminalObject/Helper/Art.php
@@ -94,7 +94,7 @@ trait Art
      */
     protected function artFile($art)
     {
-        $files = $this->fileSearch($art, '[^' . $this->directory_separator . ']*$');
+        $files = $this->fileSearch($art, '[^' . preg_quote($this->directory_separator) . ']*$');
 
         if (count($files) === 0) {
             $this->addDir(__DIR__ . '/../../ASCII');

--- a/tests/TerminalObject/Basic/DrawTest.php
+++ b/tests/TerminalObject/Basic/DrawTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace League\CLImate\Tests\TerminalObject\Basic;
+
+use League\CLImate\Tests\TestBase;
+
+class DrawTest extends TestBase
+{
+    /**
+     * @dataProvider directorySeparatorsProvider
+     */
+    public function testDirectorySeparators($directorySeparator, $message)
+    {
+        $expected = [
+            '     ( )',
+            '      H',
+            '      H',
+            '     _H_',
+            '  .-\'-.-\'-.',
+            ' /         \\',
+            '|           |',
+            '|   .-------\'._',
+            '|  / /  \'.\' \'. \\',
+            '|  \\ \\ @   @ / /',
+            '|   \'---------\'',
+            '|    _______|',
+            '|  .\'-+-+-+|',
+            '|  \'.-+-+-+|',
+            '|    """""" |',
+            '\'-.__   __.-\'',
+            '     """',
+        ];
+
+        $draw = new \League\CLImate\TerminalObject\Basic\Draw('bender');
+        $draw->directory_separator = $directorySeparator;
+        $this->assertEquals(
+            $expected,
+            $draw->result(),
+            'Bender with a ' . $message . ' directory separator'
+        );
+    }
+
+    public function directorySeparatorsProvider()
+    {
+        return [
+            [
+                '/',
+                'forward slash'
+            ],
+            [
+                '\\',
+                'backslash'
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Fixes #149 and #153.

I'm not so happy about having to create a public variable in the trait. If you know of a better way to test please do let me know!