### PR TITLE
Negative padding

### DIFF
--- a/src/TerminalObject/Dynamic/Checkbox/Checkbox.php
+++ b/src/TerminalObject/Dynamic/Checkbox/Checkbox.php
@@ -173,11 +173,8 @@ class Checkbox
      */
     protected function getPaddingString($line)
     {
-        $length = $this->util->system->width() - $this->lengthWithoutTags($line);
-        if($length < 0) {
-            $length = 0;
-        }
-
+        $length = max($this->util->system->width() - $this->lengthWithoutTags($line), 0);
+        
         return str_repeat(' ', $length);
     }
 

--- a/src/TerminalObject/Dynamic/Checkbox/Checkbox.php
+++ b/src/TerminalObject/Dynamic/Checkbox/Checkbox.php
@@ -174,6 +174,9 @@ class Checkbox
     protected function getPaddingString($line)
     {
         $length = $this->util->system->width() - $this->lengthWithoutTags($line);
+        if($length < 0) {
+            $length = 0;
+        }
 
         return str_repeat(' ', $length);
     }


### PR DESCRIPTION
When I switched my application to `php:7.4.0-fpm-alpine`, I started receiving warnings that completely ruined possibility to use your library. I was using `radio()` method and after PHP updates these showed up:
```bash
Warning: str_repeat(): Second argument has to be greater than or equal to 0 in /application/vendor/league/climate/src/TerminalObject/Dynamic/Checkbox/Checkbox.php on line 177
```

They've appeared even with the basic implementation:
```php
$cli = new CLImate();
$cli->radio("Test", [1, 2])->prompt();
```

For some reason calculated length for padding changed to a negative number (-5 for example above). I mapped `$length` variable to be always non-negative for `Checkbox` class' padding.

I had no problems with other components, so I'm leaving them as they are.