### PR TITLE
Add a method to access trailing args as array

### DIFF
--- a/src/Argument/Manager.php
+++ b/src/Argument/Manager.php
@@ -248,4 +248,14 @@ class Manager
     {
         return $this->parser->trailing();
     }
+
+    /**
+     * Get the trailing arguments as an array
+     *
+     * @return array|null
+     */
+    public function trailingArray()
+    {
+        return $this->parser->trailingArray();
+    }
 }

--- a/src/Argument/Parser.php
+++ b/src/Argument/Parser.php
@@ -22,6 +22,8 @@ class Parser
 
     protected $trailing;
 
+    protected $trailingArray;
+
     public function __construct()
     {
         $this->summary = new Summary();
@@ -108,6 +110,16 @@ class Parser
     }
 
     /**
+     * Get the trailing arguments as an array
+     *
+     * @return array|null
+     */
+    public function trailingArray()
+    {
+        return $this->trailingArray;
+    }
+
+    /**
      * Remove the trailing arguments from the parser and set them aside
      *
      * @param array $arguments
@@ -118,6 +130,7 @@ class Parser
     {
         $trailing = array_splice($arguments, array_search('--', $arguments));
         array_shift($trailing);
+        $this->trailingArray = $trailing;
         $this->trailing = implode(' ', $trailing);
 
         return $arguments;

--- a/tests/Argument/ManagerTest.php
+++ b/tests/Argument/ManagerTest.php
@@ -58,4 +58,16 @@ class ManagerTest extends TestCase
 
         $this->assertEquals('', $this->manager->get('foo'));
     }
+
+    public function testItStoresTrailingInArray()
+    {
+        $this->manager->add([
+            'foo' => ['prefix' => 'f']
+        ]);
+
+        $this->manager->parse(['command', '-f', '--', 'test', 'trailing with spaces']);
+
+        $this->assertEquals('test trailing with spaces', $this->manager->trailing());
+        $this->assertEquals(['test', 'trailing with spaces'], $this->manager->trailingArray());
+    }
 }


### PR DESCRIPTION
When using trailing arguments to pass remaining info on to another command, it would be helpful to have the arguments preserved as an array rather than a concatenated string. This pull request adds a new method to the Manager and Parser class for accessing trailing arguments as an array. It does not modify how the string value is currently handled for trailing arguments, since that would be a backwards compatibility break and require an appropriate semver increment. In the future, these duplicate values could be merged (and trailing arguments properly escaped before concatenation) as part of a backwards-incompatible change in the next major version.

If you would like me to resubmit without duplicating the properties, please let me know. I just thought I'd submit the most compatible change first and revise if requested.

Thanks for your work on this project, and for your time here!