### PR TITLE
Update PHPUnit to 9.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
 ARG PHP_VERSION=7.2
 FROM php:${PHP_VERSION}-cli
 
-# Install pickle to help manage extensions
-RUN apt-get update && apt-get install -y git libzip-dev zip && docker-php-ext-install zip
-RUN curl --location https://github.com/FriendsOfPHP/pickle/releases/latest/download/pickle.phar -o /usr/local/sbin/pickle
-RUN chmod +x /usr/local/sbin/pickle
-
 ARG COVERAGE
-RUN if [ "$COVERAGE" = "pcov" ]; then pickle install pcov && docker-php-ext-enable pcov; fi
+RUN if [ "$COVERAGE" = "pcov" ]; then pecl install pcov && docker-php-ext-enable pcov; fi
 
 # Install composer to manage PHP dependencies
+RUN apt-get update && apt-get install -y git zip
 RUN curl https://getcomposer.org/download/1.9.0/composer.phar -o /usr/local/sbin/composer
 RUN chmod +x /usr/local/sbin/composer
 RUN composer self-update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 ARG PHP_VERSION=7.2
 FROM php:${PHP_VERSION}-cli
 
+# Install pickle to help manage extensions
+RUN apt-get update && apt-get install -y git libzip-dev zip && docker-php-ext-install zip
+RUN curl --location https://github.com/FriendsOfPHP/pickle/releases/latest/download/pickle.phar -o /usr/local/sbin/pickle
+RUN chmod +x /usr/local/sbin/pickle
+
 ARG COVERAGE
-RUN if [ "$COVERAGE" = "pcov" ]; then pecl install pcov && docker-php-ext-enable pcov; fi
+RUN if [ "$COVERAGE" = "pcov" ]; then pickle install pcov && docker-php-ext-enable pcov; fi
 
 # Install composer to manage PHP dependencies
-RUN apt-get update && apt-get install -y git zip
 RUN curl https://getcomposer.org/download/1.9.0/composer.phar -o /usr/local/sbin/composer
 RUN chmod +x /usr/local/sbin/composer
 RUN composer self-update

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "seld/cli-prompt": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.16",
-        "mockery/mockery": "^1.0",
+        "phpunit/phpunit": "^9.5.0",
+        "mockery/mockery": "^1.4.2",
         "mikey179/vfsstream": "^1.4"
     },
     "suggest": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/tests/Animation/AnimationTest.php
+++ b/tests/Animation/AnimationTest.php
@@ -93,7 +93,10 @@ class AnimationTest extends TestBase
         $this->runAsc('exitRightFrameEnd', 9);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_exit_to_top()
     {
         $this->fullArtExitTop();
@@ -106,7 +109,10 @@ class AnimationTest extends TestBase
         $this->cli->animation('404', $this->getSleeper(11))->exitTo('top');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_enter_from_top()
     {
         $this->emptyFrame();
@@ -118,7 +124,10 @@ class AnimationTest extends TestBase
         $this->cli->animation('404', $this->getSleeper(11))->enterFrom('top');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_exit_to_bottom()
     {
         $this->fullArtExitBottom();
@@ -131,7 +140,10 @@ class AnimationTest extends TestBase
         $this->cli->animation('404', $this->getSleeper(11))->exitTo('bottom');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_enter_from_bottom()
     {
         $this->emptyFrame();
@@ -143,7 +155,10 @@ class AnimationTest extends TestBase
         $this->cli->animation('404', $this->getSleeper(11))->enterFrom('bottom');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_exit_to_left()
     {
         $this->fullArtExitLeft();
@@ -155,7 +170,10 @@ class AnimationTest extends TestBase
         $this->cli->animation('4', $this->getSleeper(14))->exitTo('left');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_enter_from_left()
     {
         $this->assertEnteredFromLeft();
@@ -165,7 +183,10 @@ class AnimationTest extends TestBase
         $this->cli->animation('4', $this->getSleeper(14))->enterFrom('left');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_exit_to_right()
     {
         $this->fullArtExitRight();
@@ -177,7 +198,10 @@ class AnimationTest extends TestBase
         $this->cli->animation('4', $this->getSleeper(85))->exitTo('right');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_enter_from_right()
     {
         $this->enterRightFrame1();
@@ -188,7 +212,10 @@ class AnimationTest extends TestBase
         $this->cli->animation('4', $this->getSleeper(85))->enterFrom('right');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_will_scroll_to_the_right_by_default()
     {
         $this->assertScrolledRight();
@@ -197,7 +224,10 @@ class AnimationTest extends TestBase
         $this->cli->animation('4', $this->getSleeper(91))->scroll();
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_scroll_to_the_right()
     {
         $this->assertScrolledRight();
@@ -206,7 +236,10 @@ class AnimationTest extends TestBase
         $this->cli->animation('4', $this->getSleeper(91))->scroll('right');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_scroll_to_the_left()
     {
         $this->emptyFrame();
@@ -219,7 +252,10 @@ class AnimationTest extends TestBase
         $this->cli->animation('4', $this->getSleeper(91))->scroll('left');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_scroll_up()
     {
         $this->emptyFrame();
@@ -233,7 +269,10 @@ class AnimationTest extends TestBase
         $this->cli->animation('404', $this->getSleeper(13))->scroll('up');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_scroll_down()
     {
         $this->emptyFrame();
@@ -247,7 +286,10 @@ class AnimationTest extends TestBase
         $this->cli->animation('404', $this->getSleeper(13))->scroll('down');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_run_a_directory_animation()
     {
         $this->runAsc('runFrames', 5);
@@ -257,7 +299,10 @@ class AnimationTest extends TestBase
     }
 
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_404s_when_it_gets_invalid_art()
     {
         $this->emptyFrame();

--- a/tests/AnsiTest.php
+++ b/tests/AnsiTest.php
@@ -63,9 +63,7 @@ class AnsiTest extends TestBase
         $router->execute($obj);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_will_recognize_non_ansi_systems()
     {
         $system = Mockery::mock('League\CLImate\Util\System\Windows');

--- a/tests/AnsiTest.php
+++ b/tests/AnsiTest.php
@@ -7,6 +7,7 @@ use League\CLImate\Decorator\Parser\NonAnsi;
 use League\CLImate\Decorator\Parser\ParserFactory;
 use League\CLImate\Decorator\Style;
 use League\CLImate\Decorator\Tags;
+use League\CLImate\TerminalObject;
 use League\CLImate\TerminalObject\Router\BasicRouter;
 use League\CLImate\Util\System\Linux;
 use League\CLImate\Util\System\Windows;
@@ -15,8 +16,10 @@ use Mockery;
 
 class AnsiTest extends TestBase
 {
-    /** @test */
-
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_with_ansi()
     {
         $router = new BasicRouter();
@@ -24,7 +27,6 @@ class AnsiTest extends TestBase
 
         $style  = new Style();
         $parser = new Ansi($style->current(), new Tags($style->all()));
-
         $obj = Mockery::mock('League\CLImate\TerminalObject');
         $obj->shouldReceive('result')->once()->andReturn("<green>I am green</green>");
         $obj->shouldReceive('sameLine')->once()->andReturn(false);
@@ -37,8 +39,10 @@ class AnsiTest extends TestBase
         $router->execute($obj);
     }
 
-    /** @test */
-
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_without_ansi()
     {
         $router = new BasicRouter();
@@ -59,8 +63,9 @@ class AnsiTest extends TestBase
         $router->execute($obj);
     }
 
-    /** @test */
-
+    /**
+     * @test
+     */
     public function it_will_recognize_non_ansi_systems()
     {
         $system = Mockery::mock('League\CLImate\Util\System\Windows');
@@ -71,8 +76,10 @@ class AnsiTest extends TestBase
         $this->assertInstanceOf('League\CLImate\Decorator\Parser\NonAnsi', $parser);
     }
 
-    /** @test */
-
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_will_force_ansi_on_a_non_ansi_system()
     {
         $system = new Windows();
@@ -86,8 +93,10 @@ class AnsiTest extends TestBase
         $this->cli->out("<green>I am green</green>");
     }
 
-    /** @test */
-
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_will_force_ansi_off_on_an_ansi_system()
     {
         $system = new Linux();

--- a/tests/Argument/ManagerTest.php
+++ b/tests/Argument/ManagerTest.php
@@ -10,7 +10,7 @@ class ManagerTest extends TestCase
 {
     private $manager;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->manager = new Manager;
     }

--- a/tests/BorderTest.php
+++ b/tests/BorderTest.php
@@ -4,7 +4,10 @@ namespace League\CLImate\Tests;
 
 class BorderTest extends TestBase
 {
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_basic_border()
     {
         $this->shouldWrite("\e[m" . str_repeat('-', $this->util->width() ?: 100) . "\e[0m");
@@ -12,7 +15,10 @@ class BorderTest extends TestBase
         $this->cli->border();
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_border_with_a_different_character()
     {
         $this->shouldWrite("\e[m" . str_repeat('@', $this->util->width() ?: 100) . "\e[0m");
@@ -20,7 +26,10 @@ class BorderTest extends TestBase
         $this->cli->border('@');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_border_with_a_different_length()
     {
         $this->shouldWrite("\e[m" . str_repeat('-', 60) . "\e[0m");
@@ -28,7 +37,10 @@ class BorderTest extends TestBase
         $this->cli->border('-', 60);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_border_with_an_odd_length_character_and_still_be_the_correct_length()
     {
         $this->shouldWrite("\e[m-*--*--*--*--*--*--*--*--*--*--*--*--*--*--*--*--*\e[0m");

--- a/tests/BrTest.php
+++ b/tests/BrTest.php
@@ -4,7 +4,10 @@ namespace League\CLImate\Tests;
 
 class BrTest extends TestBase
 {
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_line_break()
     {
         $this->shouldWrite("\e[m\e[0m");
@@ -13,7 +16,10 @@ class BrTest extends TestBase
         $this->cli->br();
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_is_chainable()
     {
         $this->shouldWrite("\e[m\e[0m");
@@ -23,7 +29,10 @@ class BrTest extends TestBase
         $this->cli->br()->out('This is a line further down.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_accept_the_number_of_breaks_as_an_argument()
     {
         $this->shouldWrite("\e[m\e[0m", 3);
@@ -33,7 +42,10 @@ class BrTest extends TestBase
         $this->cli->br(3)->out('This is a line further down.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_will_ignore_a_negative_number_of_breaks()
     {
         $this->shouldWrite("\e[m\e[0m");
@@ -43,7 +55,10 @@ class BrTest extends TestBase
         $this->cli->br(-3)->out('This is a line further down.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_will_ignore_a_partial_number_of_breaks()
     {
         $this->shouldWrite("\e[m\e[0m", 4);

--- a/tests/CLImateTest.php
+++ b/tests/CLImateTest.php
@@ -9,7 +9,10 @@ use League\CLImate\Tests\CustomObject\BasicObjectArgument;
 
 class CLImateTest extends TestBase
 {
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_echo_out_a_string()
     {
         $this->shouldWrite("\e[mThis would go out to the console.\e[0m");
@@ -17,7 +20,10 @@ class CLImateTest extends TestBase
         $this->cli->out('This would go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_chain_the_out_method()
     {
         $this->shouldWrite("\e[mThis is a line.\e[0m");
@@ -26,7 +32,10 @@ class CLImateTest extends TestBase
         $this->cli->out('This is a line.')->out('This is another line.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_write_content_to_a_different_output()
     {
         $this->shouldWrite("\e[mThis is to the buffer.\e[0m");
@@ -39,7 +48,10 @@ class CLImateTest extends TestBase
         $this->cli->to('buffer')->out('This is to the buffer.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_be_extended_using_a_basic_object_as_string()
     {
         $this->shouldWrite("\e[mBy Custom Object: This is something my custom object is handling.\e[0m");
@@ -49,7 +61,10 @@ class CLImateTest extends TestBase
         $this->cli->basic('This is something my custom object is handling.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_be_extended_using_a_basic_object()
     {
         $this->shouldWrite("\e[mThis just outputs this.\e[0m");
@@ -59,7 +74,10 @@ class CLImateTest extends TestBase
         $this->cli->basicObject();
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_be_extended_using_a_basic_object_with_argument_setter()
     {
         $this->shouldWrite("\e[mHey: This is the thing that will print to the console.\e[0m");
@@ -96,7 +114,10 @@ class CLImateTest extends TestBase
         $this->cli->extend($class);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_will_accept_a_custom_key_for_an_extension()
     {
         $this->shouldWrite("\e[mBy Custom Object: This is something my custom object is handling.\e[0m");

--- a/tests/ClearTest.php
+++ b/tests/ClearTest.php
@@ -4,7 +4,10 @@ namespace League\CLImate\Tests;
 
 class ClearTest extends TestBase
 {
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_clear_the_terminal()
     {
         $this->output->shouldReceive("sameLine")->andReturn(true);

--- a/tests/ColumnTest.php
+++ b/tests/ColumnTest.php
@@ -48,7 +48,10 @@ class ColumnTest extends TestBase
         ];
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_columns()
     {
         $this->shouldWrite("\e[mthis      thing     and\e[0m");
@@ -59,7 +62,10 @@ class ColumnTest extends TestBase
         $this->cli->columns($this->getStandardColumns());
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_single_item_in_one_column()
     {
         $this->shouldWrite("\e[mthis\e[0m");
@@ -68,7 +74,10 @@ class ColumnTest extends TestBase
         $this->cli->columns($this->getSingleColumn(), 1);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_less_items_than_columns()
     {
         $this->shouldWrite("\e[mthis\e[0m");
@@ -77,7 +86,10 @@ class ColumnTest extends TestBase
         $this->cli->columns($this->getSingleColumn(), 2);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_specific_number_of_columns()
     {
         $this->shouldWrite("\e[mthis      too\e[0m");
@@ -101,7 +113,10 @@ class ColumnTest extends TestBase
         $this->cli->columns($this->getStandardColumns(), 1);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_handle_multibyte_strings()
     {
         $this->shouldWrite("\e[mthis      thing     and\e[0m");
@@ -115,7 +130,10 @@ class ColumnTest extends TestBase
         $this->cli->columns($columns);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_an_associative_array_as_columns()
     {
         $this->shouldWrite("\e[mone       first one\e[0m");
@@ -128,7 +146,10 @@ class ColumnTest extends TestBase
         $this->cli->columns($this->getAssociativeColumns());
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_an_array_of_arrays_as_columns()
     {
         $this->shouldWrite("\e[mone       first one      first third column\e[0m");
@@ -141,7 +162,10 @@ class ColumnTest extends TestBase
         $this->cli->columns($this->getArrayOfArrayColumns());
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_an_uneven_array_of_arrays_as_columns()
     {
         $this->shouldWrite("\e[mone       first one      first third column\e[0m");

--- a/tests/DrawTest.php
+++ b/tests/DrawTest.php
@@ -28,7 +28,10 @@ class DrawTest extends TestBase
     }
 
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_draw_something()
     {
         $this->shouldWrite("\e[m     ( )\e[0m");
@@ -53,14 +56,20 @@ class DrawTest extends TestBase
         $this->cli->draw('bender');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_404s_when_it_gets_invalid_art()
     {
         $this->draw404();
         $this->cli->draw('something-that-doesnt-exist');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_take_a_custom_art_directory()
     {
         $this->drawWorks();
@@ -68,7 +77,10 @@ class DrawTest extends TestBase
         $this->cli->draw('works');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_take_a_custom_art_directory_with_a_trailing_slash()
     {
         $this->drawWorks();
@@ -76,7 +88,10 @@ class DrawTest extends TestBase
         $this->cli->draw('works');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_chain_the_art_setting()
     {
         $this->drawWorks();
@@ -87,6 +102,7 @@ class DrawTest extends TestBase
     /**
      * Ensure we don't use the path to match the file name.
      * https://github.com/thephpleague/climate/issues/130
+     * @doesNotPerformAssertions
      */
     public function testAddArt1()
     {
@@ -101,6 +117,7 @@ class DrawTest extends TestBase
 
     /**
      * Ensure we can draw files without extensions.
+     * @doesNotPerformAssertions
      */
     public function testDraw1()
     {
@@ -119,6 +136,7 @@ class DrawTest extends TestBase
     /**
      * Ensure we don't draw an image unless the filename matches exactly.
      * https://github.com/thephpleague/climate/issues/155
+     * @doesNotPerformAssertions
      */
     public function testDraw2()
     {

--- a/tests/DumpTest.php
+++ b/tests/DumpTest.php
@@ -6,7 +6,10 @@ require_once 'VarDumpMock.php';
 
 class DumpTest extends TestBase
 {
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_dump_a_variable()
     {
         $this->shouldWrite("\e[mDUMPED: This thing\e[0m");

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -13,7 +13,7 @@ class FileTest extends TestBase
 {
     protected $file;
 
-    public function setUp()
+    public function setUp(): void
     {
         $root       = vfsStream::setup();
         $this->file = vfsStream::newFile('log')->at($root);
@@ -82,7 +82,10 @@ class FileTest extends TestBase
         $this->assertSame("Oh, you're still here." . \PHP_EOL, $this->file->getContent());
     }
 
-    /** @test */
+    /**
+     * @codeCoverageIgnore
+     * @doesNotPerformAssertions
+     */
     public function it_can_write_to_a_gzipped_file()
     {
         // $file = $this->getFileMock($this->file->url());

--- a/tests/FlankTest.php
+++ b/tests/FlankTest.php
@@ -4,7 +4,10 @@ namespace League\CLImate\Tests;
 
 class FlankTest extends TestBase
 {
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_basic_flank()
     {
         $this->shouldWrite("\e[m### Flank me! ###\e[0m");
@@ -12,7 +15,10 @@ class FlankTest extends TestBase
         $this->cli->flank('Flank me!');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_flank_with_a_different_character()
     {
         $this->shouldWrite("\e[m--- Flank me! ---\e[0m");
@@ -20,7 +26,10 @@ class FlankTest extends TestBase
         $this->cli->flank('Flank me!', '-');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_flank_with_a_different_length()
     {
         $this->shouldWrite("\e[m##### Flank me! #####\e[0m");
@@ -28,7 +37,10 @@ class FlankTest extends TestBase
         $this->cli->flank('Flank me!', null, 5);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_flank_with_a_character_and_different_length()
     {
         $this->shouldWrite("\e[m----- Flank me! -----\e[0m");

--- a/tests/InlineTest.php
+++ b/tests/InlineTest.php
@@ -4,7 +4,10 @@ namespace League\CLImate\Tests;
 
 class InlineTest extends TestBase
 {
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_inline()
     {
         $should_be = [

--- a/tests/InputTest.php
+++ b/tests/InputTest.php
@@ -187,7 +187,10 @@ class InputTest extends TestBase
         $this->assertSame('Not much.', $response);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_will_accept_multiple_lines()
     {
         $this->shouldReadMultipleLinesAndReturn("Multiple\nLines\x04");
@@ -198,7 +201,10 @@ class InputTest extends TestBase
         $response = $input->prompt();
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_will_read_after_eof()
     {
         $this->shouldReadMultipleLinesAndReturn("Multiple\nLines\x04");

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -25,7 +25,7 @@ class LoggerTest extends TestCase
     private $cli;
 
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->cli = Mockery::mock(CLImate::class);
 
@@ -37,7 +37,7 @@ class LoggerTest extends TestCase
     }
 
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }
@@ -62,91 +62,117 @@ class LoggerTest extends TestCase
         new Logger(15);
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testEmergency()
     {
         $this->cli->shouldReceive("emergency")->once()->with("Testing emergency");
         $this->logger->emergency("Testing emergency");
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testAlert()
     {
         $this->cli->shouldReceive("alert")->once()->with("Testing alert");
         $this->logger->alert("Testing alert");
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testCritical()
     {
         $this->cli->shouldReceive("critical")->once()->with("Testing critical");
         $this->logger->critical("Testing critical");
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testError()
     {
         $this->cli->shouldReceive("error")->once()->with("Testing error");
         $this->logger->error("Testing error");
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testWarning()
     {
         $this->cli->shouldReceive("warning")->once()->with("Testing warning");
         $this->logger->warning("Testing warning");
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testNotice()
     {
         $this->cli->shouldReceive("notice")->once()->with("Testing notice");
         $this->logger->notice("Testing notice");
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testInfo()
     {
         $this->cli->shouldReceive("info")->once()->with("Testing info");
         $this->logger->info("Testing info");
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testDebug()
     {
         $this->cli->shouldReceive("debug")->once()->with("Testing debug");
         $this->logger->debug("Testing debug");
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testLog()
     {
         $this->cli->shouldReceive("critical")->once()->with("Testing log");
         $this->logger->log(LogLevel::CRITICAL, "Testing log");
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testLevelEmergency()
     {
         $this->cli->shouldReceive(LogLevel::EMERGENCY)->once()->with("Testing log");
         $this->logger->withLogLevel(LogLevel::EMERGENCY)->emergency("Testing log");
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testLevelAlert()
     {
         $this->cli->shouldReceive("alert")->never();
         $this->logger->withLogLevel(LogLevel::EMERGENCY)->alert("Testing log");
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testLevelNotice()
     {
         $this->cli->shouldReceive(LogLevel::NOTICE)->once()->with("Notice");
         $this->logger->withLogLevel(LogLevel::NOTICE)->notice("Notice");
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testLevelDebug()
     {
         $this->cli->shouldReceive(LogLevel::DEBUG)->once()->with("Debug");
@@ -167,7 +193,9 @@ class LoggerTest extends TestCase
         $this->logger->withLogLevel(0);
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testContext()
     {
         $this->cli->shouldReceive("info")->once()->with("With context");
@@ -182,14 +210,18 @@ class LoggerTest extends TestCase
         ]);
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testEmptyContext()
     {
         $this->cli->shouldReceive("info")->once()->with("No context");
         $this->logger->info("No context", []);
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testPlaceholders()
     {
         $this->cli->shouldReceive("info")->once()->with("I am Spartacus!");
@@ -198,7 +230,9 @@ class LoggerTest extends TestCase
         ]);
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testPlaceholdersAndContext()
     {
         $this->cli->shouldReceive("info")->once()->with("I am Spartacus!");
@@ -214,7 +248,9 @@ class LoggerTest extends TestCase
         ]);
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testRecursiveContext()
     {
         $this->cli->shouldReceive("info")->once()->with("INFO");

--- a/tests/OutputTest.php
+++ b/tests/OutputTest.php
@@ -9,7 +9,10 @@ use function get_class;
 
 class OutputTest extends TestBase
 {
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_content()
     {
         $out = Mockery::mock('League\CLImate\Util\Writer\StdOut');
@@ -22,7 +25,10 @@ class OutputTest extends TestBase
         $output->write('Oh, hey there.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_content_without_a_new_line()
     {
         $out = Mockery::mock('League\CLImate\Util\Writer\StdOut');
@@ -35,7 +41,10 @@ class OutputTest extends TestBase
         $output->sameLine()->write('Oh, hey there.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_default_to_a_writer()
     {
         $error = Mockery::mock('League\CLImate\Util\Writer\StdErr');
@@ -49,7 +58,10 @@ class OutputTest extends TestBase
         $output->sameLine()->write('Oh, hey there.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_default_to_multiple_writers()
     {
         $out = Mockery::mock('League\CLImate\Util\Writer\StdOut');
@@ -67,7 +79,10 @@ class OutputTest extends TestBase
         $output->sameLine()->write('Oh, hey there.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_add_a_default()
     {
         $out = Mockery::mock('League\CLImate\Util\Writer\StdOut');
@@ -86,7 +101,10 @@ class OutputTest extends TestBase
         $output->sameLine()->write('Oh, hey there.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_handle_multiple_writers_for_one_key()
     {
         $out = Mockery::mock('League\CLImate\Util\Writer\StdOut');
@@ -103,7 +121,10 @@ class OutputTest extends TestBase
         $output->sameLine()->write('Oh, hey there.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_take_existing_writer_keys_and_resolve_them()
     {
         $out = Mockery::mock('League\CLImate\Util\Writer\StdOut');
@@ -182,7 +203,10 @@ class OutputTest extends TestBase
         $output->add('out', ['nothin']);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_write_to_a_non_default_writer_once()
     {
         $out = Mockery::mock('League\CLImate\Util\Writer\StdOut');
@@ -202,7 +226,10 @@ class OutputTest extends TestBase
         $output->sameLine()->write('Second time.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_will_persist_writer_if_told_to()
     {
         $out = Mockery::mock('League\CLImate\Util\Writer\StdOut');

--- a/tests/PaddingTest.php
+++ b/tests/PaddingTest.php
@@ -4,7 +4,10 @@ namespace League\CLImate\Tests;
 
 class PaddingTest extends TestBase
 {
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_wrap_a_line()
     {
         $max_width = $this->util->width();
@@ -21,7 +24,10 @@ class PaddingTest extends TestBase
         $padding->label($content)->result('result');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_chain()
     {
         $padding = $this->cli->padding(10);
@@ -33,7 +39,10 @@ class PaddingTest extends TestBase
         $padding->label('Pad me')->result('extra');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_pad_with_multiple_characters()
     {
         $padding = $this->cli->padding(10)->char('.-');
@@ -45,7 +54,10 @@ class PaddingTest extends TestBase
         $padding->label('Pad me')->result('extra');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_pad_with_multiple_characters_odd()
     {
         $padding = $this->cli->padding(10)->char('.-');
@@ -58,7 +70,10 @@ class PaddingTest extends TestBase
     }
 
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_pad_with_multibyte_characters()
     {
         $padding = $this->cli->padding(10);
@@ -70,8 +85,10 @@ class PaddingTest extends TestBase
         $padding->label("Лорем")->result("END");
     }
 
-
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_wrap_a_multibyte_line()
     {
         $max_width = $this->util->width();

--- a/tests/ProgressTest.php
+++ b/tests/ProgressTest.php
@@ -32,7 +32,10 @@ class ProgressTest extends TestBase
         return $bar;
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_progress_bar()
     {
         $this->shouldWrite('');
@@ -55,7 +58,10 @@ class ProgressTest extends TestBase
         }
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_progress_bar_via_constructor()
     {
         $this->shouldWrite('');
@@ -78,7 +84,10 @@ class ProgressTest extends TestBase
         }
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_progress_bar_with_current_labels()
     {
         $this->shouldWrite('');
@@ -115,7 +124,10 @@ class ProgressTest extends TestBase
         }
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_progress_bar_with_current_optional_labels()
     {
         $this->shouldWrite('');
@@ -138,7 +150,10 @@ class ProgressTest extends TestBase
         }
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_styled_progress_bar()
     {
         $this->shouldWrite('');
@@ -161,7 +176,10 @@ class ProgressTest extends TestBase
         }
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_styled_progress_bar_and_resets_the_style()
     {
         $this->shouldWrite('');
@@ -213,7 +231,10 @@ class ProgressTest extends TestBase
         $progress->current(2);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_progress_bar_using_increments()
     {
         $this->shouldWrite('');
@@ -232,7 +253,10 @@ class ProgressTest extends TestBase
     }
 
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_progress_bar_using_increments_with_label()
     {
         $this->shouldWrite('');
@@ -246,7 +270,10 @@ class ProgressTest extends TestBase
         $progress->advance(8, 'final');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_will_force_a_redraw_if_specified()
     {
         $this->shouldWrite('');
@@ -268,7 +295,10 @@ class ProgressTest extends TestBase
         }
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_will_not_force_a_redraw_if_disabled()
     {
         $this->shouldWrite('');
@@ -289,7 +319,9 @@ class ProgressTest extends TestBase
         }
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testEach1()
     {
         $this->shouldWrite('');
@@ -326,6 +358,10 @@ class ProgressTest extends TestBase
 
         $this->assertSame(["key2" => "two", "key1" => "one"], $items);
     }
+
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testEach4()
     {
         $this->shouldWrite('');

--- a/tests/SleeperTest.php
+++ b/tests/SleeperTest.php
@@ -8,7 +8,10 @@ require_once 'SleeperGlobalMock.php';
 
 class SleeperTest extends TestBase
 {
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_slow_down_the_sleeper_speed()
     {
         $sleeper = new Sleeper;
@@ -22,7 +25,10 @@ class SleeperTest extends TestBase
         $sleeper->sleep();
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_speed_up_the_sleeper_speed()
     {
         $sleeper = new Sleeper;
@@ -36,7 +42,10 @@ class SleeperTest extends TestBase
         $sleeper->sleep();
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_will_ignore_zero_percentages()
     {
         $sleeper = new Sleeper;

--- a/tests/StyleTest.php
+++ b/tests/StyleTest.php
@@ -4,7 +4,10 @@ namespace League\CLImate\Tests;
 
 class StyleTest extends TestBase
 {
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_use_a_foreground_color_method()
     {
         $this->shouldWrite("\e[31mThis would go out to the console.\e[0m");
@@ -12,7 +15,10 @@ class StyleTest extends TestBase
         $this->cli->red('This would go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_resets_itself_after_styled_output()
     {
         $this->shouldWrite("\e[31mThis would go out to the console.\e[0m");
@@ -23,7 +29,10 @@ class StyleTest extends TestBase
         $this->cli->out('This is plain.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_use_a_background_color_method()
     {
         $this->shouldWrite("\e[41mThis would go out to the console.\e[0m");
@@ -31,7 +40,10 @@ class StyleTest extends TestBase
         $this->cli->backgroundRed('This would go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_use_a_background_color_method_chained()
     {
         $this->shouldWrite("\e[41mThis would go out to the console.\e[0m");
@@ -39,7 +51,10 @@ class StyleTest extends TestBase
         $this->cli->backgroundRed()->out('This would go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_apply_a_format()
     {
         $this->shouldWrite("\e[5mThis would go out to the console.\e[0m");
@@ -47,7 +62,10 @@ class StyleTest extends TestBase
         $this->cli->blink('This would go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_apply_multiple_formats()
     {
         $this->shouldWrite("\e[4;5mThis would go out to the console.\e[0m");
@@ -55,7 +73,10 @@ class StyleTest extends TestBase
         $this->cli->underline()->blink('This would go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_chain_a_foreground_color_method()
     {
         $this->shouldWrite("\e[31mThis would go out to the console.\e[0m");
@@ -63,7 +84,10 @@ class StyleTest extends TestBase
         $this->cli->red()->out('This would go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_use_a_background_color_and_foreground_color_method()
     {
         $this->shouldWrite("\e[31;41mThis would go out to the console.\e[0m");
@@ -71,7 +95,10 @@ class StyleTest extends TestBase
         $this->cli->backgroundRed()->red('This would go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_use_a_background_color_and_foreground_color_and_format_method()
     {
         $this->shouldWrite("\e[5;31;41mThis would go out to the console.\e[0m");
@@ -79,7 +106,10 @@ class StyleTest extends TestBase
         $this->cli->backgroundRed()->blink()->red('This would go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_parse_foreground_color_tags()
     {
         $this->shouldWrite("\e[mThis \e[31mwould\e[0m go out to the console.\e[0m");
@@ -87,7 +117,10 @@ class StyleTest extends TestBase
         $this->cli->out('This <red>would</red> go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_parse_background_color_tags()
     {
         $this->shouldWrite("\e[mThis \e[41mwould\e[0m go out to the console.\e[0m");
@@ -95,7 +128,10 @@ class StyleTest extends TestBase
         $this->cli->out('This <background_red>would</background_red> go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_parse_formatting_tags()
     {
         $this->shouldWrite("\e[mThis \e[5mwould\e[0m go out to the console.\e[0m");
@@ -103,7 +139,10 @@ class StyleTest extends TestBase
         $this->cli->out('This <blink>would</blink> go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_parse_nested_tags()
     {
         $this->shouldWrite("\e[mThis \e[31m\e[5mwould\e[0;31m (still red)\e[0m go out to the console.\e[0m");
@@ -111,7 +150,10 @@ class StyleTest extends TestBase
         $this->cli->out('This <red><blink>would</blink> (still red)</red> go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_parse_tags_and_return_to_current_style()
     {
         $this->shouldWrite("\e[31mThis \e[5mwould\e[0;31m go out to the console.\e[0m");
@@ -119,7 +161,10 @@ class StyleTest extends TestBase
         $this->cli->red('This <blink>would</blink> go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_add_a_color_and_use_it()
     {
         $this->shouldWrite("\e[900mThis is the new color.\e[0m");
@@ -129,7 +174,10 @@ class StyleTest extends TestBase
         $this->cli->newCustomColor('This is the new color.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_add_a_color_and_use_it_as_a_tag()
     {
         $this->shouldWrite("\e[mThis \e[900mis\e[0m the new color.\e[0m");
@@ -139,7 +187,10 @@ class StyleTest extends TestBase
         $this->cli->out('This <new_custom_color>is</new_custom_color> the new color.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_add_a_color_and_use_it_as_a_background()
     {
         $this->shouldWrite("\e[910mThis is the new color.\e[0m");
@@ -149,7 +200,10 @@ class StyleTest extends TestBase
         $this->cli->backgroundNewCustomColor()->out('This is the new color.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_use_a_color_command()
     {
         $this->shouldWrite("\e[91mThis would go out to the console.\e[0m");
@@ -157,7 +211,10 @@ class StyleTest extends TestBase
         $this->cli->error('This would go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_chain_a_color_command()
     {
         $this->shouldWrite("\e[91mThis would go out to the console.\e[0m");
@@ -165,7 +222,10 @@ class StyleTest extends TestBase
         $this->cli->error()->out('This would go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_use_add_a_command_via_a_string()
     {
         $this->shouldWrite("\e[94mThis would go out to the console.\e[0m");
@@ -175,7 +235,10 @@ class StyleTest extends TestBase
         $this->cli->holler('This would go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_use_a_string_command_as_a_tag()
     {
         $this->shouldWrite("\e[mThis would go \e[94mout\e[0m to the console.\e[0m");
@@ -185,7 +248,10 @@ class StyleTest extends TestBase
         $this->cli->out('This would go <holler>out</holler> to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_use_add_a_command_via_an_array()
     {
         $this->shouldWrite("\e[1;4;41;94mThis would go out to the console.\e[0m");
@@ -196,7 +262,10 @@ class StyleTest extends TestBase
         $this->cli->holler('This would go out to the console.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_use_an_array_command_as_a_tag()
     {
         $this->shouldWrite("\e[mThis would go \e[1;4;41;94mout\e[0m to the console.\e[0m");

--- a/tests/TabTest.php
+++ b/tests/TabTest.php
@@ -4,7 +4,10 @@ namespace League\CLImate\Tests;
 
 class TabTest extends TestBase
 {
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_tab()
     {
         $this->output->shouldReceive("sameLine");
@@ -15,7 +18,10 @@ class TabTest extends TestBase
         $this->cli->tab();
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_is_chainable()
     {
         $this->output->shouldReceive("sameLine");
@@ -27,7 +33,10 @@ class TabTest extends TestBase
         $this->cli->tab()->out('This is indented.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_accept_the_number_of_tabs_as_an_argument()
     {
         $this->output->shouldReceive("sameLine");
@@ -39,7 +48,10 @@ class TabTest extends TestBase
         $this->cli->tab(3)->out('This is really indented.');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_will_ignore_a_negative_number_of_tabs()
     {
         $this->output->shouldReceive("sameLine");
@@ -50,7 +62,10 @@ class TabTest extends TestBase
         $this->cli->tab(-3);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_will_ignore_a_partial_number_of_tabs()
     {
         $this->output->shouldReceive("sameLine");

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -6,7 +6,10 @@ use League\CLImate\Exceptions\InvalidArgumentException;
 
 class TableTest extends TestBase
 {
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_a_basic_table()
     {
         $this->shouldWrite("\e[m-------------------------------------\e[0m");
@@ -25,7 +28,10 @@ class TableTest extends TestBase
         ]);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_an_array_of_objects_table()
     {
         $this->shouldWrite("\e[m-------------------------------------\e[0m");
@@ -46,7 +52,10 @@ class TableTest extends TestBase
             ]);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_an_array_of_associative_arrays_table()
     {
         $this->shouldWrite("\e[m-------------------------------------\e[0m");
@@ -67,7 +76,10 @@ class TableTest extends TestBase
             ]);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_persist_a_style_on_the_table()
     {
         $this->shouldWrite("\e[31m-------------------------------------\e[0m");
@@ -88,7 +100,10 @@ class TableTest extends TestBase
             ]);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_handle_tags_within_the_data()
     {
         $this->shouldWrite("\e[m-------------------------------------\e[0m");
@@ -109,7 +124,10 @@ class TableTest extends TestBase
             ]);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_handle_multi_byte_characters()
     {
         $this->shouldWrite("\e[m-------------------------------------\e[0m");
@@ -130,7 +148,10 @@ class TableTest extends TestBase
             ]);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_handle_the_same_value_more_than_once()
     {
         $this->shouldWrite("\e[m-------------------------------------\e[0m");
@@ -151,7 +172,9 @@ class TableTest extends TestBase
             ]);
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testTableWithPrefix1()
     {
         $this->shouldWrite("\e[m\t-----------\e[0m");

--- a/tests/TerminalObject/Basic/ClearLineTest.php
+++ b/tests/TerminalObject/Basic/ClearLineTest.php
@@ -7,7 +7,9 @@ use League\CLImate\Tests\TestBase;
 class ClearLineTest extends TestBase
 {
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testClearOneLine()
     {
         $this->output->shouldReceive("sameLine")->andReturn(true);
@@ -16,7 +18,9 @@ class ClearLineTest extends TestBase
         $this->cli->clearLine();
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testClearTwoLines()
     {
         $this->output->shouldReceive("sameLine")->andReturn(true);

--- a/tests/TerminalObject/Basic/JsonTest.php
+++ b/tests/TerminalObject/Basic/JsonTest.php
@@ -8,7 +8,10 @@ use function str_replace;
 
 class JsonTest extends TestBase
 {
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_an_object_as_json()
     {
         $json = json_encode((object) [
@@ -33,7 +36,9 @@ class JsonTest extends TestBase
      * We do this test specifically because json escapes the tags,
      * we want to make sure we"re taking care of that
      *
-     * @test */
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_output_json_with_tags()
     {
         $json = json_encode((object) [
@@ -56,6 +61,9 @@ class JsonTest extends TestBase
         ]);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function test_we_dont_escape_slashes()
     {
         $this->shouldWrite("\e[m{\n    \"package\": \"league/climate\"\n}\e[0m");

--- a/tests/TerminalObject/Dynamic/SpinnerTest.php
+++ b/tests/TerminalObject/Dynamic/SpinnerTest.php
@@ -13,7 +13,9 @@ class SpinnerTest extends TestBase
         usleep(1000000);
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testBasic()
     {
         $this->shouldWrite("\e[m[-=---]\e[0m");
@@ -31,7 +33,9 @@ class SpinnerTest extends TestBase
         $spinner->advance();
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testQuick()
     {
         $this->shouldWrite("\e[m[-=---]\e[0m");
@@ -42,7 +46,9 @@ class SpinnerTest extends TestBase
         $spinner->advance();
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testWithLabels()
     {
         $this->shouldWrite("\e[m[-=---] one\e[0m");
@@ -60,7 +66,9 @@ class SpinnerTest extends TestBase
         $spinner->advance("three");
     }
 
-
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testWithOptionalLabels()
     {
         $this->shouldWrite("\e[m[-=---] one\e[0m");

--- a/tests/TerminalObjectTest.php
+++ b/tests/TerminalObjectTest.php
@@ -4,7 +4,10 @@ namespace League\CLImate\Tests;
 
 class TerminalObjectTest extends TestBase
 {
-    /** @test **/
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_gracefully_handles_non_existent_objects()
     {
         $this->shouldWrite("\e[mHey there.\e[0m");
@@ -14,7 +17,10 @@ class TerminalObjectTest extends TestBase
         $this->cli->somethingThatDoesntExist('Hey there.');
     }
 
-    /** @test **/
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_chain_a_foreground_color_and_terminal_object()
     {
         $this->shouldWrite("\e[31m### Flank me! ###\e[0m");
@@ -24,7 +30,10 @@ class TerminalObjectTest extends TestBase
         $this->cli->red()->flank('Flank me!');
     }
 
-    /** @test **/
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_chain_a_background_color_and_terminal_object()
     {
         $this->shouldWrite("\e[41m### Flank me! ###\e[0m");
@@ -34,7 +43,10 @@ class TerminalObjectTest extends TestBase
         $this->cli->backgroundRed()->flank('Flank me!');
     }
 
-    /** @test **/
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_combine_a_foreground_color_and_terminal_object()
     {
         $this->shouldWrite("\e[31m### Flank me! ###\e[0m");
@@ -44,7 +56,10 @@ class TerminalObjectTest extends TestBase
         $this->cli->redFlank('Flank me!');
     }
 
-    /** @test **/
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_combine_a_background_color_and_terminal_object()
     {
         $this->shouldWrite("\e[41m### Flank me! ###\e[0m");
@@ -54,7 +69,10 @@ class TerminalObjectTest extends TestBase
         $this->cli->backgroundRedFlank('Flank me!');
     }
 
-    /** @test **/
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_chain_a_format_and_terminal_object()
     {
         $this->shouldWrite("\e[5m### Flank me! ###\e[0m");
@@ -64,7 +82,10 @@ class TerminalObjectTest extends TestBase
         $this->cli->blink()->flank('Flank me!');
     }
 
-    /** @test **/
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_combine_a_format_and_terminal_object()
     {
         $this->shouldWrite("\e[5m### Flank me! ###\e[0m");
@@ -74,7 +95,10 @@ class TerminalObjectTest extends TestBase
         $this->cli->blinkFlank('Flank me!');
     }
 
-    /** @test **/
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_combine_multiple_formats_and_terminal_object()
     {
         $this->shouldWrite("\e[4;5m### Flank me! ###\e[0m");
@@ -84,7 +108,10 @@ class TerminalObjectTest extends TestBase
         $this->cli->blinkUnderlineFlank('Flank me!');
     }
 
-    /** @test **/
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_combine_a_foreground_and_background_color_and_terminal_object()
     {
         $this->shouldWrite("\e[31;41m### Flank me! ###\e[0m");
@@ -94,7 +121,10 @@ class TerminalObjectTest extends TestBase
         $this->cli->redBackgroundRedFlank('Flank me!');
     }
 
-    /** @test **/
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_can_combine_a_format_and_foreground_and_background_color_and_terminal_object()
     {
         $this->shouldWrite("\e[5;31;41m### Flank me! ###\e[0m");

--- a/tests/TestBase.php
+++ b/tests/TestBase.php
@@ -24,7 +24,7 @@ class TestBase extends TestCase
 
     protected $record_it = false;
 
-    public function setUp()
+    public function setUp(): void
     {
         self::$functions = Mockery::mock();
 
@@ -45,7 +45,7 @@ class TestBase extends TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }
@@ -119,7 +119,10 @@ class TestBase extends TestCase
         $this->output->shouldReceive('persist')->with(false)->times($times)->andReturn($this->output);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
     public function it_does_nothing()
     {
         // nada


### PR DESCRIPTION
- PhpUnit upgraded to 9.5.0
- Annotation `@doesNotPerformAssertions` added to tests that have no assertions.
- Removed `syntaxCheck` attribute from phpunit.xml as this is no longer a valid attribute.