### PR TITLE
Fixed: systemHasAnsiSupport() throws an error when STDOUT is not defined

### DIFF
--- a/src/Util/System/Linux.php
+++ b/src/Util/System/Linux.php
@@ -86,19 +86,23 @@ class Linux extends System
         if ('Hyper' === getenv('TERM_PROGRAM')) {
             return true;
         }
-        
-        $stream = STDOUT;
-        
-        if (function_exists('stream_isatty')) {
-            return @stream_isatty($stream);
+
+        if (defined(STDOUT)) {
+            $stream = STDOUT;
+
+            if (function_exists('stream_isatty')) {
+                return @stream_isatty($stream);
+            }
+
+            if (function_exists('posix_isatty')) {
+                return @posix_isatty($stream);
+            }
+
+            $stat = @fstat($stream);
+            // Check if formatted mode is S_IFCHR
+            return $stat && 0020000 === ($stat['mode'] & 0170000);
         }
 
-        if (function_exists('posix_isatty')) {
-            return @posix_isatty($stream);
-        }
-
-        $stat = @fstat($stream);
-        // Check if formatted mode is S_IFCHR
-        return $stat ? 0020000 === ($stat['mode'] & 0170000) : false;
+        return false;
     }
 }


### PR DESCRIPTION
`Util/System/Linux::systemHasAnsiSupport()` throws an error in the cases where the constant STDOUT is undefined.
Fixed `systemHasAnsiSupport()` to return false in this instance.

Closes: #172
See: https://stackoverflow.com/questions/17769041/notice-use-of-undefined-constant-stdout-assumed-stdout/28898174