### PR TITLE
PHP Deprecated:  strlen(): Passing null to parameter #1 (php 8.1)

### DIFF
--- a/src/TerminalObject/Basic/BasicTerminalObject.php
+++ b/src/TerminalObject/Basic/BasicTerminalObject.php
@@ -18,7 +18,7 @@ abstract class BasicTerminalObject implements BasicTerminalObjectInterface
      */
     protected function set($key, $value)
     {
-        if (strlen($value)) {
+        if (is_string($value) && strlen($value)) {
             $this->$key = $value;
         }
     }


### PR DESCRIPTION
If we do not pass the 2nd argument in border (php 8.1).

```php 
$climate->border('-');
```

![изображение](https://user-images.githubusercontent.com/5681979/152529614-2a0efd28-7aa3-4d21-9dde-74e004f3e361.png)

![изображение](https://user-images.githubusercontent.com/5681979/152529650-920a791c-9787-4463-912a-980f581cf91f.png)

