### PR TITLE
Update psr/log to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
         }
     ],
     "require": {
-        "psr/log": "^1.0",
-        "php": "^7.3 || ^8.0",
-        "seld/cli-prompt": "^1.0"
+        "php": ">=8.0",
+        "seld/cli-prompt": "^1.0",
+        "psr/log": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.0",


### PR DESCRIPTION
Tried to install with Slim v4 and got an error that psr/log was locked at v1.0.

So this PR just updates psr/log to v3. That also means only php 8+ is supported, which I think is probably the correct thing to do anyways since 7.4 is out of official support now