### PR TITLE
Bug in php 8.1

### DIFF
--- a/src/TerminalObject/Helper/Sleeper.php
+++ b/src/TerminalObject/Helper/Sleeper.php
@@ -32,6 +32,6 @@ class Sleeper implements SleeperInterface
      */
     public function sleep()
     {
-        usleep($this->speed);
+        usleep((int)$this->speed);
     }
 }


### PR DESCRIPTION
[ErrorException]

Implicit conversion from float 33333.33333333333 to int loses precision