### PR TITLE
Fix PHP 8.5 deprecation: null as array offset in isArgument()

### DIFF
--- a/src/Argument/Manager.php
+++ b/src/Argument/Manager.php
@@ -171,15 +171,15 @@ class Manager
      */
     protected function isArgument($argument, $command_argument)
     {
-        $possibilities = [
-            $argument->prefix()     => "-{$argument->prefix()}",
-            $argument->longPrefix() => "--{$argument->longPrefix()}",
-        ];
+        $prefix = $argument->prefix();
+        $longPrefix = $argument->longPrefix();
 
-        foreach ($possibilities as $key => $search) {
-            if ($key && strpos($command_argument, $search) === 0) {
-                return true;
-            }
+        if ($prefix !== null && strpos($command_argument, "-{$prefix}") === 0) {
+            return true;
+        }
+
+        if ($longPrefix !== null && strpos($command_argument, "--{$longPrefix}") === 0) {
+            return true;
         }
 
         return false;


### PR DESCRIPTION
## Problem

PHP 8.5 deprecates using `null` as an array offset. `Argument::prefix()` and `Argument::longPrefix()` can return `null`, which was used as array keys in `Manager::isArgument()`:

```
Deprecated: Using null as an array offset is deprecated, use an empty string instead
in src/Argument/Manager.php on line 175
```

## Fix

Refactored `isArgument()` to check each prefix individually with explicit null guards instead of building an array with potentially null keys. The behavior is unchanged — null prefixes are skipped.